### PR TITLE
Switch to TinyStr

### DIFF
--- a/unic-langid-impl/Cargo.toml
+++ b/unic-langid-impl/Cargo.toml
@@ -9,6 +9,9 @@ repository = "https://github.com/zbraniecki/unic-locale"
 license = "MIT/Apache-2.0"
 categories = ["internationalization"]
 
+[dependencies]
+tinystr = "0.1"
+
 [dev-dependencies]
 criterion = "0.2"
 serde = { version = "1.0", features = ["derive"] }

--- a/unic-langid-impl/benches/langid.rs
+++ b/unic-langid-impl/benches/langid.rs
@@ -1,95 +1,95 @@
 use criterion::criterion_group;
 use criterion::criterion_main;
 use criterion::Criterion;
+use criterion::Fun;
 
+use tinystr::{TinyStr4, TinyStr8};
 use unic_langid_impl::LanguageIdentifier;
 
-fn language_identifier_from_str_bench(c: &mut Criterion) {
-    let strings = &[
-        "en-US",
-        "en-GB",
-        "es-AR",
-        "it",
-        "zh-Hans-CN",
-        "de-AT",
-        "pl",
-        "fr-FR",
-        "de-AT",
-        "sr-Cyrl-SR",
-        "nb-NO",
-        "fr-FR",
-        "mk",
-        "uk",
+static STRINGS: &[&str] = &[
+    "en-US",
+    "en-GB",
+    "es-AR",
+    "it",
+    "zh-Hans-CN",
+    "de-AT",
+    "pl",
+    "fr-FR",
+    "de-AT",
+    "sr-Cyrl-SR",
+    "nb-NO",
+    "fr-FR",
+    "mk",
+    "uk",
+];
+
+fn language_identifier_construct_bench(c: &mut Criterion) {
+    let langids: Vec<LanguageIdentifier> = STRINGS
+        .iter()
+        .map(|s| -> LanguageIdentifier { s.parse().unwrap() })
+        .collect();
+
+    let funcs = vec![
+        Fun::new("from_str", |b, _| {
+            b.iter(|| {
+                for s in STRINGS {
+                    let _: Result<LanguageIdentifier, _> = s.parse();
+                }
+            })
+        }),
+        Fun::new("from_parts", |b, langids: &Vec<LanguageIdentifier>| {
+            let entries: Vec<(Option<&str>, Option<&str>, Option<&str>, Vec<&str>)> = langids
+                .iter()
+                .map(|langid| {
+                    let lang = Some(langid.get_language()).and_then(|s| {
+                        if s == "und" {
+                            None
+                        } else {
+                            Some(s)
+                        }
+                    });
+                    (
+                        lang,
+                        langid.get_script(),
+                        langid.get_region(),
+                        langid.get_variants(),
+                    )
+                })
+                .collect();
+            b.iter(|| {
+                for (language, script, region, variants) in &entries {
+                    let _ = LanguageIdentifier::from_parts(*language, *script, *region, variants);
+                }
+            })
+        }),
+        Fun::new(
+            "from_parts_unchecked",
+            |b, langids: &Vec<LanguageIdentifier>| {
+                let entries = langids
+                    .iter()
+                    .map(|langid| langid.clone().to_raw_parts())
+                    .collect::<Vec<_>>();
+                b.iter(|| {
+                    for (language, script, region, variants) in &entries {
+                        let _ = unsafe {
+                            LanguageIdentifier::from_raw_parts_unchecked(
+                                language.map(|l| TinyStr8::new_unchecked(l)),
+                                script.map(|s| TinyStr4::new_unchecked(s)),
+                                region.map(|r| TinyStr4::new_unchecked(r)),
+                                variants
+                                    .into_iter()
+                                    .map(|v| TinyStr8::new_unchecked(*v))
+                                    .collect(),
+                            )
+                        };
+                    }
+                })
+            },
+        ),
     ];
-    c.bench_function("language_identifier_from_str", move |b| {
-        b.iter(|| {
-            for s in strings {
-                let _: Result<LanguageIdentifier, _> = s.parse();
-            }
-        })
-    });
+
+    c.bench_functions("language_identifier_construct", funcs, langids);
 }
 
-fn language_identifier_from_parts_bench(c: &mut Criterion) {
-    let entries: Vec<(Option<&str>, Option<&str>, Option<&str>, Option<&[&&str]>)> = vec![
-        (Some("en"), None, Some("US"), None),
-        (Some("en"), None, Some("GB"), None),
-        (Some("es"), None, Some("AR"), None),
-        (Some("it"), None, None, None),
-        (Some("zh"), Some("Hans"), Some("CN"), None),
-        (Some("de"), None, Some("AT"), None),
-        (Some("pl"), None, None, None),
-        (Some("fr"), None, Some("FR"), None),
-        (Some("de"), None, Some("AT"), None),
-        (Some("sr"), Some("Cyrl"), Some("SR"), None),
-        (Some("nb"), None, Some("NO"), None),
-        (Some("fr"), None, Some("FR"), None),
-        (Some("mk"), None, None, None),
-        (Some("uk"), None, None, None),
-    ];
-    c.bench_function("language_identifier_from_parts", move |b| {
-        b.iter(|| {
-            for (language, region, script, variants) in &entries {
-                let _ = LanguageIdentifier::from_parts(
-                    language.as_ref(),
-                    region.as_ref(),
-                    script.as_ref(),
-                    *variants,
-                );
-            }
-        })
-    });
-
-    let entries2: Vec<(Option<&str>, Option<&str>, Option<&str>, Option<&[&str]>)> = vec![
-        (Some("en"), None, Some("US"), None),
-        (Some("en"), None, Some("GB"), None),
-        (Some("es"), None, Some("AR"), None),
-        (Some("it"), None, None, None),
-        (Some("zh"), Some("Hans"), Some("CN"), None),
-        (Some("de"), None, Some("AT"), None),
-        (Some("pl"), None, None, None),
-        (Some("fr"), None, Some("FR"), None),
-        (Some("de"), None, Some("AT"), None),
-        (Some("sr"), Some("Cyrl"), Some("SR"), None),
-        (Some("nb"), None, Some("NO"), None),
-        (Some("fr"), None, Some("FR"), None),
-        (Some("mk"), None, None, None),
-        (Some("uk"), None, None, None),
-    ];
-    c.bench_function("language_identifier_from_parts_unchecked", move |b| {
-        b.iter(|| {
-            for (language, region, script, variants) in &entries2 {
-                let _ = LanguageIdentifier::from_parts_unchecked(
-                    *language, *region, *script, *variants,
-                );
-            }
-        })
-    });
-}
-
-criterion_group!(
-    benches,
-    language_identifier_from_str_bench,
-    language_identifier_from_parts_bench,,
-);
+criterion_group!(benches, language_identifier_construct_bench,);
 criterion_main!(benches);

--- a/unic-langid-impl/src/parser/mod.rs
+++ b/unic-langid-impl/src/parser/mod.rs
@@ -45,11 +45,12 @@ pub fn parse_language_identifier(t: &str) -> Result<LanguageIdentifier, ParserEr
     }
 
     variants.sort();
+    variants.dedup();
 
     Ok(LanguageIdentifier {
         language,
         script,
         region,
-        variants,
+        variants: variants.into_boxed_slice(),
     })
 }

--- a/unic-langid-impl/tests/fixtures.rs
+++ b/unic-langid-impl/tests/fixtures.rs
@@ -16,7 +16,8 @@ struct LangIdTestOutputObject {
     language: Option<String>,
     script: Option<String>,
     region: Option<String>,
-    variants: Option<Vec<String>>,
+    #[serde(default)]
+    variants: Vec<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -49,10 +50,14 @@ fn test_langid_fixtures(path: &str) {
         match test.output {
             LangIdTestOutput::Object(o) => {
                 let expected = LanguageIdentifier::from_parts(
-                    o.language,
-                    o.script,
-                    o.region,
-                    o.variants.as_ref().map(|v| v.as_slice()),
+                    o.language.as_ref().map(String::as_str),
+                    o.script.as_ref().map(String::as_str),
+                    o.region.as_ref().map(String::as_str),
+                    o.variants
+                        .iter()
+                        .map(|s| s.as_str())
+                        .collect::<Vec<_>>()
+                        .as_ref(),
                 )
                 .expect("Parsing failed.");
                 assert_eq!(langid, expected);

--- a/unic-langid-impl/tests/fixtures/parsing.json
+++ b/unic-langid-impl/tests/fixtures/parsing.json
@@ -147,5 +147,14 @@
     "output": {
       "script": "Latn"
     }
+  },
+  {
+    "input": {
+      "string": "pl-macos-Windows-nedis-macos-nedis-aRabic"
+    },
+    "output": {
+      "language": "pl",
+      "variants": ["arabic", "macos", "nedis", "windows"]
+    }
   }
 ]

--- a/unic-langid-impl/tests/language_identifier_test.rs
+++ b/unic-langid-impl/tests/language_identifier_test.rs
@@ -1,3 +1,4 @@
+use tinystr::{TinyStr4, TinyStr8};
 use unic_langid_impl::parser::parse_language_identifier;
 use unic_langid_impl::LanguageIdentifier;
 
@@ -54,14 +55,25 @@ fn test_sorted_variants() {
     assert_eq!(&langid.to_string(), "en-macos-nedis");
 
     let langid =
-        LanguageIdentifier::from_parts(Some("en"), None, None, Some(&["nedis", "macos"])).unwrap();
+        LanguageIdentifier::from_parts(Some("en"), None, None, &["nedis", "macos"]).unwrap();
     assert_eq!(&langid.to_string(), "en-macos-nedis");
 }
 
 #[test]
 fn test_from_parts_unchecked() {
-    let langid =
-        LanguageIdentifier::from_parts_unchecked(Some("en"), None, None, Some(&["macos", "nedis"]));
+    let langid: LanguageIdentifier = "en-nedis-macos".parse().unwrap();
+    let (lang, script, region, variants) = langid.to_raw_parts();
+    let langid = unsafe {
+        LanguageIdentifier::from_raw_parts_unchecked(
+            lang.map(|l| TinyStr8::new_unchecked(l)),
+            script.map(|s| TinyStr4::new_unchecked(s)),
+            region.map(|r| TinyStr4::new_unchecked(r)),
+            variants
+                .into_iter()
+                .map(|v| TinyStr8::new_unchecked(*v))
+                .collect(),
+        )
+    };
     assert_eq!(&langid.to_string(), "en-macos-nedis");
 }
 

--- a/unic-langid-macros-impl/Cargo.toml
+++ b/unic-langid-macros-impl/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["internationalization"]
 proc_macro = true
 
 [dependencies]
-unic-langid-impl = "0.4"
+unic-langid-impl = { path = "../unic-langid-impl" }
 syn = "0.15"
 quote = "0.6"
 proc-macro-hack = "0.5"

--- a/unic-langid-macros-impl/src/lib.rs
+++ b/unic-langid-macros-impl/src/lib.rs
@@ -13,32 +13,29 @@ pub fn langid(input: TokenStream) -> TokenStream {
     let id = parse_macro_input!(input as LitStr);
     let parsed: LanguageIdentifier = id.value().parse().expect("Malformed Language Identifier");
 
-    let lang = parsed.get_language();
-    let lang = if lang.is_empty() {
-        quote!(None)
+    let (lang, script, region, variants) = parsed.to_raw_parts();
+    let lang = if let Some(lang) = lang {
+        quote!(Some($crate::TinyStr8::new_unchecked(#lang)))
     } else {
-        quote!(Some(#lang))
+        quote!(None)
     };
-    let script = parsed.get_script();
     let script = if let Some(script) = script {
-        quote!(Some(#script))
+        quote!(Some($crate::TinyStr4::new_unchecked(#script)))
     } else {
         quote!(None)
     };
-    let region = parsed.get_region();
     let region = if let Some(region) = region {
-        quote!(Some(#region))
+        quote!(Some($crate::TinyStr4::new_unchecked(#region)))
     } else {
         quote!(None)
     };
-    let variants = parsed.get_variants();
-    let variants = if variants.is_empty() {
-        quote!(None)
-    } else {
-        quote!(Some(&[#(#variants,)*]))
-    };
+    let variants: Vec<_> = variants
+        .into_iter()
+        .map(|v| quote!($crate::TinyStr8::new_unchecked(#v)))
+        .collect();
+    let variants = quote!(Box::new([#(#variants,)*]));
 
     TokenStream::from(quote! {
-        $crate::LanguageIdentifier::from_parts_unchecked(#lang, #script, #region, #variants)
+        unsafe { $crate::LanguageIdentifier::from_raw_parts_unchecked(#lang, #script, #region, #variants) }
     })
 }

--- a/unic-langid-macros/Cargo.toml
+++ b/unic-langid-macros/Cargo.toml
@@ -11,5 +11,6 @@ categories = ["internationalization"]
 
 [dependencies]
 proc-macro-hack = "0.5"
-unic-langid-macros-impl = "0.3"
-unic-langid-impl = "0.4"
+unic-langid-macros-impl = { path = "../unic-langid-macros-impl" }
+unic-langid-impl = { path = "../unic-langid-impl" }
+tinystr = "0.1"

--- a/unic-langid-macros/src/lib.rs
+++ b/unic-langid-macros/src/lib.rs
@@ -1,4 +1,5 @@
 use proc_macro_hack::proc_macro_hack;
+pub use tinystr::{TinyStr4, TinyStr8};
 pub use unic_langid_impl::LanguageIdentifier;
 
 /// Add one to an expression.

--- a/unic-langid/Cargo.toml
+++ b/unic-langid/Cargo.toml
@@ -10,11 +10,10 @@ license = "MIT/Apache-2.0"
 categories = ["internationalization"]
 
 [dependencies]
-unic-langid-impl = "0.4"
-unic-langid-macros = { version = "0.3", optional = true }
-
+unic-langid-impl = { path = "../unic-langid-impl" }
+unic-langid-macros = { path = "../unic-langid-macros", optional = true }
 [dev-dependencies]
-unic-langid-macros = "0.3"
+unic-langid-macros = { path = "../unic-langid-macros" }
 
 [features]
 default = []

--- a/unic-langid/examples/simple-langid.rs
+++ b/unic-langid/examples/simple-langid.rs
@@ -2,6 +2,9 @@
 use unic_langid::langid;
 use unic_langid::LanguageIdentifier;
 
+// This will become possible when Box can be produced in a const fn
+// static LANGID: LanguageIdentifier = langid!("en-US");
+
 fn main() {
     let langid: LanguageIdentifier = "en-US".parse().unwrap();
     println!("{:#?}", langid);


### PR DESCRIPTION
This is a port of https://github.com/projectfluent/fluent-locale-rs/pull/8/files to unic-langid.

It's a WIP patch, but it works and passes all tests. I think there are couple more optimizations possible and I'd also like to get feedback from the author on my attempt to separate `try_new` from `new_unchecked`.

Performance looks good, except of the unchecked:

```
     Running /Users/zbraniecki/projects/unic-locale/target/release/deps/canonicalize-de07a657eb9bbd6d
Gnuplot not found, disabling plotting
langid_canonicalize     time:   [3.1782 us 3.1955 us 3.2135 us]                                 
                        change: [-38.116% -37.401% -36.763%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) low mild
  1 (1.00%) high mild

Gnuplot not found, disabling plotting
     Running /Users/zbraniecki/projects/unic-locale/target/release/deps/langid-c1dada57b49294d8
Gnuplot not found, disabling plotting
language_identifier_from_str                                                                             
                        time:   [512.60 ns 513.77 ns 515.01 ns]
                        change: [-84.009% -83.919% -83.827%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  5 (5.00%) low mild
  4 (4.00%) high mild

language_identifier_from_parts                                                                            
                        time:   [293.03 ns 294.23 ns 295.60 ns]
                        change: [-89.997% -89.930% -89.862%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  3 (3.00%) low mild
  5 (5.00%) high mild
  3 (3.00%) high severe

language_identifier_from_parts_unchecked                                                                            
                        time:   [220.00 ns 221.03 ns 222.26 ns]
                        change: [+49.424% +50.201% +50.996%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 6 outliers among 100 measurements (6.00%)
  1 (1.00%) low severe
  1 (1.00%) low mild
  2 (2.00%) high mild
  2 (2.00%) high severe

Gnuplot not found, disabling plotting
     Running /Users/zbraniecki/projects/unic-locale/target/release/deps/parser-9a3dedd695250831
Gnuplot not found, disabling plotting
language_identifier_parser                                                                            
                        time:   [432.51 ns 433.59 ns 434.83 ns]
                        change: [-85.793% -85.707% -85.617%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  1 (1.00%) low mild
  5 (5.00%) high mild
  3 (3.00%) high severe

language_identifier_parser_casing                                                                            
                        time:   [432.55 ns 433.62 ns 434.78 ns]
                        change: [-85.559% -85.467% -85.376%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  2 (2.00%) low mild
  6 (6.00%) high mild

Gnuplot not found, disabling plotting
```

This patch so far is backwards compatible which is super nice. But I'm now wondering if it should return `TinyStr` from `get_*` methods (which, I assume, would make the unchecked constructor cheaper/faster), but it would be a breaking change and would let people operate on TinyStr rather than str. Not sure if it's worth it...