### PR TITLE
Stub optional Validity information for LanguageIdentifier

### DIFF
--- a/unic-langid-impl/Cargo.toml
+++ b/unic-langid-impl/Cargo.toml
@@ -17,6 +17,9 @@ criterion = "0.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 
+[features]
+validity = []
+
 [[bench]]
 name = "parser"
 harness = false

--- a/unic-langid-impl/src/parser/mod.rs
+++ b/unic-langid-impl/src/parser/mod.rs
@@ -76,6 +76,7 @@ pub fn parse_language_identifier(
             script,
             region,
             variants: variants.into_boxed_slice(),
+            is_valid: None,
         },
         exception,
     ))

--- a/unic-langid-impl/src/validity/mod.rs
+++ b/unic-langid-impl/src/validity/mod.rs
@@ -1,0 +1,22 @@
+use crate::LanguageIdentifier;
+
+pub trait IsValid {
+  fn is_valid(&self) -> Option<bool>;
+
+  fn validate(&mut self) -> Result<(), ()>;
+}
+
+impl IsValid for LanguageIdentifier {
+  fn is_valid(&self) -> Option<bool> {
+    self.is_valid
+  }
+
+  fn validate(&mut self) -> Result<(), ()> {
+    // Here's we'll pull:
+    //  * ISO 639-1 or ISO 639-2 for language codes validation
+    //  * ISO-15924 for scripts
+    //  * ISO-3166 for regions
+    self.is_valid = Some(true);
+    Ok(())
+  }
+}

--- a/unic-langid-impl/tests/canonicalize_test.rs
+++ b/unic-langid-impl/tests/canonicalize_test.rs
@@ -1,7 +1,11 @@
-use unic_langid_impl::canonicalize;
+use unic_langid_impl::LanguageIdentifier;
 
 fn assert_canonicalize(input: &str, output: &str) {
-    assert_eq!(&canonicalize(input).unwrap(), output);
+    assert_eq!(LanguageIdentifier::canonicalize_str(input).unwrap(), output);
+}
+
+fn assert_is_well_formed(input: &str, output: bool) {
+    assert_eq!(LanguageIdentifier::is_str_well_formed(input), output);
 }
 
 #[test]
@@ -9,4 +13,11 @@ fn test_canonicalize() {
     assert_canonicalize("Pl", "pl");
     assert_canonicalize("eN-uS", "en-US");
     assert_canonicalize("ZH_hans_hK", "zh-Hans-HK");
+}
+
+#[test]
+fn is_well_formed() {
+    assert_is_well_formed("Pl", true);
+    assert_is_well_formed("und", true);
+    assert_is_well_formed("DE-latn", true);
 }

--- a/unic-langid-macros-impl/src/lib.rs
+++ b/unic-langid-macros-impl/src/lib.rs
@@ -13,7 +13,7 @@ pub fn langid(input: TokenStream) -> TokenStream {
     let id = parse_macro_input!(input as LitStr);
     let parsed: LanguageIdentifier = id.value().parse().expect("Malformed Language Identifier");
 
-    let (lang, script, region, variants) = parsed.to_raw_parts();
+    let (lang, script, region, variants, is_valid) = parsed.to_raw_parts();
     let lang = if let Some(lang) = lang {
         quote!(Some($crate::TinyStr8::new_unchecked(#lang)))
     } else {
@@ -36,6 +36,6 @@ pub fn langid(input: TokenStream) -> TokenStream {
     let variants = quote!(Box::new([#(#variants,)*]));
 
     TokenStream::from(quote! {
-        unsafe { $crate::LanguageIdentifier::from_raw_parts_unchecked(#lang, #script, #region, #variants) }
+        unsafe { $crate::LanguageIdentifier::from_raw_parts_unchecked(#lang, #script, #region, #variants, #is_valid) }
     })
 }

--- a/unic-langid/Cargo.toml
+++ b/unic-langid/Cargo.toml
@@ -20,3 +20,5 @@ default = []
 
 # Provide macros.
 macros = ["unic-langid-macros"]
+
+validity = ["unic-langid-impl/validity"]

--- a/unic-langid/examples/simple-langid.rs
+++ b/unic-langid/examples/simple-langid.rs
@@ -10,6 +10,17 @@ fn main() {
     println!("{:#?}", langid);
     assert_eq!(langid.get_language(), "en");
 
+    #[cfg(feature = "validity")]
+    {
+        use unic_langid::validity::IsValid;
+
+        let mut langid: LanguageIdentifier = "en-US".parse().unwrap();
+        assert_eq!(langid.is_valid(), None);
+        assert_eq!(langid.validate().is_ok(), true);
+        assert_eq!(langid.is_valid(), Some(true));
+        println!("{:#?}", langid);
+    }
+
     #[cfg(feature = "unic-langid-macros")]
     {
         let langid = langid!("de-AT");


### PR DESCRIPTION
This is a stub for how I imagine the validity to work.

For context, there are three "levels" of correctness of a language identifier:
 * well-formed - LanguageIdentifier parses input and in result every language identifier is well formed
 * valid - this requires data-heavy tables to test fields against. would like to keep it optional
 * canonical - this requires more tables to update fields from obsolete tags. May add one day as another optional feature

I keep the `well-formed` as core of the library, and want to add `validity` as an optional feature, since many users will not need it at all.

I also keep two static methods `is_str_well_formed` to allow people to test if a `&str` is well formed without constructing the. struct (may optimize in the future further), and `canonicalize_str` which currently just performs parsing, but if `validity` is on may also test for validity and one day update canonical fields.

I think the `canonical` level is going to be very rarely needed, so I'd like to just make sure that the well-formed and valid levels have good clean APIs.

Spec: https://unicode.org/reports/tr35/#Unicode_language_identifier

@Manishearth - what do you think about such approach?