### PR TITLE
Fix running examples with 'cargo run --all-features --example simple-langid'

### DIFF
--- a/unic-langid-macros/examples/langid-macro.rs
+++ b/unic-langid-macros/examples/langid-macro.rs
@@ -7,6 +7,7 @@ const PL_PL: LanguageIdentifier = langid!("pl-PL");
 
 fn main() {
     println!("{:#?}", PL_PL);
+
     let id = langid!("de-Latn-DE");
-    println!("{:?}", id);
+    println!("{:#?}", id);
 }

--- a/unic-locale-macros/examples/locale-macro.rs
+++ b/unic-locale-macros/examples/locale-macro.rs
@@ -2,5 +2,5 @@ use unic_locale_macros::locale;
 
 fn main() {
     let loc = locale!("de-Latn-DE");
-    println!("{:?}", loc);
+    println!("{:#?}", loc);
 }

--- a/unic-locale/examples/simple-locale.rs
+++ b/unic-locale/examples/simple-locale.rs
@@ -3,18 +3,21 @@ use unic_locale::locale;
 use unic_locale::Locale;
 
 fn main() {
-    let locale: Locale = "en-US".parse().unwrap();
-    assert_eq!(locale.get_language(), "en");
+    let mut locale: Locale = "fr-CA".parse().unwrap();
+    locale
+        .extensions
+        .unicode
+        .set_keyword("ca", vec!["buddhist"])
+        .expect("Setting extension failed.");
+
+    println!("{:#?}", locale);
+    assert_eq!(locale.get_language(), "fr");
+    assert_eq!(&locale.to_string(), "fr-CA-u-ca-buddhist");
 
     #[cfg(feature = "macros")]
     {
-        let mut locale = locale!("en-US");
-        locale
-            .extensions
-            .unicode
-            .set_keyword("ca", vec!["buddhist"])
-            .expect("Setting extension failed.");
-        assert_eq!(locale.get_language(), "en");
-        assert_eq!(&locale.to_string(), "en-US-u-ca-buddhist");
+        let langid = locale!("de-AT");
+        println!("{:#?}", langid);
+        assert_eq!(langid.get_language(), "de");
     }
 }


### PR DESCRIPTION
simple-langid and simple-locale failed with similar error messages as they were building two versions of some of the impl crates.

1. I have updated the simple-locale to have similar examples to simple-langid, and moved the extensions stuff out of the macros feature test.
1. Unfortunately the locale! macro cannot be used to make a const it seems so that part isn't in simple-locale.
1. I have then fixed the above issue by synchronising all the `unic-langid-impl` and `unic-locale-impl` versions. However maybe this should bump the versions of the `*-macros-*` crates and require a bump of all those too?

Original output
```
% cargo run --all-features --example simple-langid
   Compiling proc-macro2 v1.0.5
   Compiling unicode-xid v0.2.0
   Compiling syn v1.0.5
   Compiling tinystr v0.3.1
   Compiling unic-langid-impl v0.5.2
   Compiling unic-langid-impl v0.6.0
   Compiling quote v1.0.2
   Compiling proc-macro-hack v0.5.10
   Compiling unic-langid-macros-impl v0.5.0
   Compiling unic-langid-macros v0.5.0
   Compiling unic-langid v0.6.0 (/Users/harry/Development/unic-locale/unic-langid)
error[E0308]: mismatched types
 --> unic-langid/examples/simple-langid.rs:6:35
  |
6 | const EN_US: LanguageIdentifier = langid!("en-US");
  |                                   ^^^^^^^^^^^^^^^^ expected struct `unic_langid_impl::LanguageIdentifier`, found a different struct `unic_langid_impl::LanguageIdentifier`
  |
  = note: expected type `unic_langid_impl::LanguageIdentifier` (struct `unic_langid_impl::LanguageIdentifier`)
             found type `unic_langid_impl::LanguageIdentifier` (struct `unic_langid_impl::LanguageIdentifier`)
note: Perhaps two different versions of crate `unic_langid_impl` are being used?
 --> unic-langid/examples/simple-langid.rs:6:35
  |
6 | const EN_US: LanguageIdentifier = langid!("en-US");
  |                                   ^^^^^^^^^^^^^^^^
  = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)

error: aborting due to previous error

For more information about this error, try `rustc --explain E0308`.
error: could not compile `unic-langid`.

To learn more, run the command again with --verbose.
```