### PR TITLE
Fix `remove_likely_subtags` when lang, script and region are all available

### DIFF
--- a/unic-langid-impl/src/likelysubtags/mod.rs
+++ b/unic-langid-impl/src/likelysubtags/mod.rs
@@ -89,7 +89,15 @@ pub fn remove_likely_subtags(
     script: Option<TinyStr4>,
     region: Option<TinyStr4>,
 ) -> Option<(Option<TinyStr8>, Option<TinyStr4>, Option<TinyStr4>)> {
-    let max_langid = add_likely_subtags(lang, script, region)?;
+
+    // add_likely_subtags returns None when all 3 components are
+    // already filled so don't call it in that case.
+    let max_langid;
+    if lang.is_some() && script.is_some() && region.is_some() {
+        max_langid = (lang, script, region);
+    } else {
+        max_langid = add_likely_subtags(lang, script, region)?;
+    }
 
     if let Some(trial) = add_likely_subtags(max_langid.0, None, None) {
         if trial == max_langid {

--- a/unic-langid-impl/tests/likelysubtags.rs
+++ b/unic-langid-impl/tests/likelysubtags.rs
@@ -96,4 +96,10 @@ fn remove_likely_subtags_test() {
     let script: TinyStr4 = "Hant".parse().unwrap();
     let result = remove_likely_subtags(Some(lang), Some(script), None);
     assert_eq!(result, Some(extract_input("zh-TW")));
+
+    let lang: TinyStr8 = "en".parse().unwrap();
+    let script: TinyStr4 = "Latn".parse().unwrap();
+    let region: TinyStr4 = "US".parse().unwrap();
+    let result = remove_likely_subtags(Some(lang), Some(script), Some(region));
+    assert_eq!(result, Some(extract_input("en")));
 }


### PR DESCRIPTION
* `add_likely_subtags` returns None in this case which was passed through.

This fixes the tests with `cargo test --all-features`.