### PR TITLE
Add get_* and remove_* for extensions

### DIFF
--- a/unic-locale-impl/src/extensions/private.rs
+++ b/unic-locale-impl/src/extensions/private.rs
@@ -50,6 +50,23 @@ impl PrivateExtensionList {
         Ok(self.0.contains(&parse_value(tag.as_ref())?))
     }
 
+    /// Returns an iterator over all tags in the `PrivateExtensionList`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use unic_locale_impl::Locale;
+    ///
+    /// let mut lo: Locale = "en-US-x-foo-bar".parse()
+    ///     .expect("Parsing failed.");
+    ///
+    /// assert_eq!(lo.extensions.private.get_tags().collect::<Vec<_>>(),
+    ///            &["bar", "foo"]);
+    /// ```
+    pub fn get_tags(&self) -> impl ExactSizeIterator<Item = &str> {
+        self.0.iter().map(|s| s.as_ref())
+    }
+
     /// Adds a tag to the `PrivateExtensionList`.
     ///
     /// # Examples

--- a/unic-locale-impl/src/extensions/private.rs
+++ b/unic-locale-impl/src/extensions/private.rs
@@ -16,14 +16,106 @@ fn parse_value(t: &[u8]) -> Result<TinyStr8, ParserError> {
 }
 
 impl PrivateExtensionList {
+    /// Returns `true` if there are no tags in the PrivateExtensionList`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use unic_locale_impl::Locale;
+    ///
+    /// let mut lo: Locale = "en-US-x-foo".parse()
+    ///     .expect("Parsing failed.");
+    ///
+    /// assert_eq!(lo.extensions.private.is_empty(), false);
+    /// ```
     pub fn is_empty(&self) -> bool {
         self.0.is_empty()
     }
 
+    /// Returns `true` if tag is included in the `PrivateExtensionList`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use unic_locale_impl::Locale;
+    ///
+    /// let mut lo: Locale = "en-US-x-foo".parse()
+    ///     .expect("Parsing failed.");
+    ///
+    /// assert_eq!(lo.extensions.private.has_tag("foo")
+    ///                .expect("Getting tag failed."),
+    ///            true);
+    /// ```
+    pub fn has_tag<S: AsRef<[u8]>>(&self, tag: S) -> Result<bool, LocaleError> {
+        Ok(self.0.contains(&parse_value(tag.as_ref())?))
+    }
+
+    /// Adds a tag to the `PrivateExtensionList`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use unic_locale_impl::Locale;
+    ///
+    /// let mut lo: Locale = "en-US".parse()
+    ///     .expect("Parsing failed.");
+    ///
+    /// lo.extensions.private.add_tag("foo")
+    ///     .expect("Adding tag failed.");
+    ///
+    /// assert_eq!(lo.to_string(), "en-US-x-foo");
+    /// ```
     pub fn add_tag<S: AsRef<[u8]>>(&mut self, tag: S) -> Result<(), LocaleError> {
         self.0.push(parse_value(tag.as_ref())?);
         self.0.sort();
         Ok(())
+    }
+
+    /// Removes a tag from the `PrivateExtensionList`.
+    ///
+    /// Returns `true` if tag was included in the `PrivateExtensionList` before
+    /// removal.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use unic_locale_impl::Locale;
+    ///
+    /// let mut lo: Locale = "en-US-x-foo".parse()
+    ///     .expect("Parsing failed.");
+    ///
+    /// assert_eq!(lo.extensions.private.remove_tag("foo")
+    ///                .expect("Removing tag failed."),
+    ///            true);
+    ///
+    /// assert_eq!(lo.to_string(), "en-US");
+    /// ```
+    pub fn remove_tag<S: AsRef<[u8]>>(&mut self, tag: S) -> Result<bool, LocaleError> {
+        let value = parse_value(tag.as_ref())?;
+        match self.0.binary_search(&value) {
+            Ok(idx) => {
+                self.0.remove(idx);
+                Ok(true)
+            },
+            Err(_) => Ok(false)
+        }
+    }
+
+    /// Clears all tags from the `PrivateExtensionList`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use unic_locale_impl::Locale;
+    ///
+    /// let mut lo: Locale = "en-US-x-foo".parse()
+    ///     .expect("Parsing failed.");
+    ///
+    /// lo.extensions.private.clear_tags();
+    /// assert_eq!(lo.to_string(), "en-US");
+    /// ```
+    pub fn clear_tags(&mut self) {
+        self.0.clear();
     }
 
     pub(crate) fn try_from_iter<'a>(

--- a/unic-locale-impl/src/extensions/transform.rs
+++ b/unic-locale-impl/src/extensions/transform.rs
@@ -159,6 +159,23 @@ impl TransformExtensionList {
         Ok(tfields.iter().map(|s| s.as_ref()))
     }
 
+    /// Returns an iterator over all tkeys in the `TransformExtensionList`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use unic_locale_impl::Locale;
+    ///
+    /// let mut lo: Locale = "en-US-t-k0-dvorak-h0-hybrid".parse()
+    ///     .expect("Parsing failed.");
+    ///
+    /// assert_eq!(lo.extensions.transform.get_tfield_tkeys().collect::<Vec<_>>(),
+    ///            &["h0", "k0"]);
+    /// ```
+    pub fn get_tfield_tkeys(&self) -> impl ExactSizeIterator<Item = &str> {
+        self.tfields.keys().map(|s| s.as_ref())
+    }
+
     /// Adds a tfield to the `TransformExtensionList` or sets tvalue for tkey if
     /// tfield is already included in the `TransformExtensionList`.
     ///

--- a/unic-locale-impl/src/extensions/transform.rs
+++ b/unic-locale-impl/src/extensions/transform.rs
@@ -47,15 +47,139 @@ fn is_language_subtag(t: &[u8]) -> bool {
 }
 
 impl TransformExtensionList {
+    /// Returns `true` if there are no tfields and no tlang in
+    /// the `TransformExtensionList`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use unic_locale_impl::Locale;
+    ///
+    /// let mut lo: Locale = "en-US-t-es-AR".parse()
+    ///     .expect("Parsing failed.");
+    ///
+    /// assert_eq!(lo.extensions.transform.is_empty(), false);
+    /// ```
     pub fn is_empty(&self) -> bool {
         self.tlang.is_none() && self.tfields.is_empty()
     }
 
+    /// Gets tlang from the `TransformExtensionList`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use unic_locale_impl::Locale;
+    /// use unic_langid_impl::LanguageIdentifier;
+    ///
+    /// let mut lo: Locale = "en-US-t-es-AR".parse()
+    ///     .expect("Parsing failed.");
+    ///
+    /// let tlang: LanguageIdentifier = "es-AR".parse()
+    ///     .expect("Parsing failed on tlang.");
+    ///
+    /// assert_eq!(lo.extensions.transform.get_tlang(), &Some(tlang));
+    /// ```
+    pub fn get_tlang(&self) -> &Option<LanguageIdentifier> {
+        &self.tlang
+    }
+
+    /// Sets tlang on the `TransformExtensionList`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use unic_locale_impl::Locale;
+    /// use unic_langid_impl::LanguageIdentifier;
+    ///
+    /// let mut lo: Locale = "en-US".parse()
+    ///     .expect("Parsing failed.");
+    ///
+    /// let tlang: LanguageIdentifier = "es-AR".parse()
+    ///     .expect("Parsing failed on tlang.");
+    ///
+    /// lo.extensions.transform.set_tlang(tlang)
+    ///     .expect("Setting tlang failed.");
+    ///
+    /// assert_eq!(lo.to_string(), "en-US-t-es-AR");
+    /// ```
     pub fn set_tlang(&mut self, tlang: LanguageIdentifier) -> Result<(), LocaleError> {
         self.tlang = Some(tlang);
         Ok(())
     }
 
+    /// Clears tlang on the `TransformExtensionList`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use unic_locale_impl::Locale;
+    /// use unic_langid_impl::LanguageIdentifier;
+    ///
+    /// let mut lo: Locale = "en-US-t-es-AR".parse()
+    ///     .expect("Parsing failed.");
+    ///
+    /// lo.extensions.transform.clear_tlang();
+    ///
+    /// assert_eq!(lo.to_string(), "en-US");
+    /// ```
+    pub fn clear_tlang(&mut self) {
+        self.tlang = None;
+    }
+
+    /// Returns the tvalue of tfield in the `TransformExtensionList`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use unic_locale_impl::Locale;
+    ///
+    /// let mut lo: Locale = "en-US-t-k0-dvorak".parse()
+    ///     .expect("Parsing failed.");
+    ///
+    /// assert_eq!(lo.extensions.transform.get_tfield("k0")
+    ///                .expect("Getting tfield failed.")
+    ///                .collect::<Vec<_>>(),
+    ///            &["dvorak"]);
+    ///
+    /// // Here tfield with tkey "m0" is not available
+    /// assert_eq!(lo.extensions.transform.get_tfield("m0")
+    ///                .expect("Getting tfield failed.")
+    ///                .collect::<Vec<_>>()
+    ///                .is_empty(),
+    ///            true);
+    /// ```
+    pub fn get_tfield<S: AsRef<[u8]>>(&self, tkey: S)
+            -> Result<impl ExactSizeIterator<Item = &str>, LocaleError> {
+        let tfields: &[_] = match self.tfields.get(&parse_tkey(tkey.as_ref())?) {
+            Some(ref v) => &**v,
+            None => &[],
+        };
+
+        Ok(tfields.iter().map(|s| s.as_ref()))
+    }
+
+    /// Adds a tfield to the `TransformExtensionList` or sets tvalue for tkey if
+    /// tfield is already included in the `TransformExtensionList`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use unic_locale_impl::Locale;
+    ///
+    /// let mut lo: Locale = "en-US".parse()
+    ///     .expect("Parsing failed.");
+    ///
+    /// lo.extensions.transform.set_tfield("k0", &["dvorak"])
+    ///     .expect("Setting tfield failed.");
+    ///
+    /// assert_eq!(lo.to_string(), "en-US-t-k0-dvorak");
+    ///
+    /// lo.extensions.transform.set_tfield("k0", &["colemak"])
+    ///     .expect("Setting tfield failed.");
+    ///
+    /// assert_eq!(lo.to_string(), "en-US-t-k0-colemak");
+    /// ```
     pub fn set_tfield<S: AsRef<[u8]>>(&mut self, tkey: S, tvalue: &[S]) -> Result<(), LocaleError> {
         let tkey = parse_tkey(tkey.as_ref())?;
         let mut t = Vec::with_capacity(tvalue.len());
@@ -67,6 +191,46 @@ impl TransformExtensionList {
 
         self.tfields.insert(tkey, t);
         Ok(())
+    }
+
+    /// Removes a tfield from the `TransformExtensionList`.
+    ///
+    /// Returns `true` if tfield was included in the `TransformExtensionList`
+    /// before removal.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use unic_locale_impl::Locale;
+    ///
+    /// let mut lo: Locale = "en-US-t-k0-dvorak".parse()
+    ///     .expect("Parsing failed.");
+    ///
+    /// assert_eq!(lo.extensions.transform.remove_tfield("k0")
+    ///                .expect("Removing tfield failed."),
+    ///            true);
+    ///
+    /// assert_eq!(lo.to_string(), "en-US");
+    /// ```
+    pub fn remove_tfield<S: AsRef<[u8]>>(&mut self, tkey: S) -> Result<bool, LocaleError> {
+        Ok(self.tfields.remove(&parse_tkey(tkey.as_ref())?).is_some())
+    }
+
+    /// Clears all tfields from the `TransformExtensionList`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use unic_locale_impl::Locale;
+    ///
+    /// let mut lo: Locale = "en-US-t-k0-dvorak".parse()
+    ///     .expect("Parsing failed.");
+    ///
+    /// lo.extensions.transform.clear_tfields();
+    /// assert_eq!(lo.to_string(), "en-US");
+    /// ```
+    pub fn clear_tfields(&mut self) {
+        self.tfields.clear();
     }
 
     pub(crate) fn try_from_iter<'a>(

--- a/unic-locale-impl/src/extensions/unicode.rs
+++ b/unic-locale-impl/src/extensions/unicode.rs
@@ -111,6 +111,23 @@ impl UnicodeExtensionList {
         Ok(keywords.iter().map(|s| s.as_ref()))
     }
 
+    /// Returns an iterator over all keys in the `UnicodeExtensionList`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use unic_locale_impl::Locale;
+    ///
+    /// let mut lo: Locale = "en-US-u-ca-buddhist-nu-thai".parse()
+    ///     .expect("Parsing failed.");
+    ///
+    /// assert_eq!(lo.extensions.unicode.get_keyword_keys().collect::<Vec<_>>(),
+    ///            &["ca", "nu"]);
+    /// ```
+    pub fn get_keyword_keys(&self) -> impl ExactSizeIterator<Item = &str> {
+        self.keywords.keys().map(|s| s.as_ref())
+    }
+
     /// Adds a keyword to the `UnicodeExtensionList` or sets value for key if
     /// keyword is already included in the `UnicodeExtensionList`.
     ///
@@ -204,6 +221,23 @@ impl UnicodeExtensionList {
     /// ```
     pub fn has_attribute<S: AsRef<[u8]>>(&self, attribute: S) -> Result<bool, LocaleError> {
         Ok(self.attributes.contains(&parse_attribute(attribute.as_ref())?))
+    }
+
+    /// Returns an iterator over all attributes in the `UnicodeExtensionList`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use unic_locale_impl::Locale;
+    ///
+    /// let mut lo: Locale = "en-US-u-foo-bar".parse()
+    ///     .expect("Parsing failed.");
+    ///
+    /// assert_eq!(lo.extensions.unicode.get_attributes().collect::<Vec<_>>(),
+    ///            &["bar", "foo"]);
+    /// ```
+    pub fn get_attributes(&self) -> impl ExactSizeIterator<Item = &str> {
+        self.attributes.iter().map(|s| s.as_ref())
     }
 
     /// Sets an attribute on the `UnicodeExtensionList`.

--- a/unic-locale-impl/tests/locale_test.rs
+++ b/unic-locale-impl/tests/locale_test.rs
@@ -40,6 +40,42 @@ fn test_locale_identifier() {
     extensions.unicode.set_keyword("hc", &["h12"]).unwrap();
     assert_parsed_locale_identifier("pl-u-hc-h12", &extensions);
 
+    extensions.unicode.set_attribute("foo").unwrap();
+    assert_parsed_locale_identifier("pl-u-foo-hc-h12", &extensions);
+
+    let val = extensions.unicode.get_keyword("hc").unwrap().collect::<Vec<_>>();
+    assert_eq!(val, &["h12"]);
+
+    let val = extensions.unicode.get_keyword("aa").unwrap().collect::<Vec<_>>();
+    assert_eq!(val.is_empty(), true);
+
+    let val = extensions.unicode.remove_keyword("hc").unwrap();
+    assert_eq!(val, true);
+    assert_parsed_locale_identifier("pl-u-foo", &extensions);
+
+    let val = extensions.unicode.has_attribute("foo").unwrap();
+    assert_eq!(val, true);
+
+    let val = extensions.unicode.has_attribute("aaa").unwrap();
+    assert_eq!(val, false);
+
+    let val = extensions.unicode.remove_attribute("foo").unwrap();
+    assert_eq!(val, true);
+    assert_parsed_locale_identifier("pl", &extensions);
+
+    extensions.transform.set_tfield("m0", &["foo"]).unwrap();
+    assert_parsed_locale_identifier("pl-t-m0-foo", &extensions);
+
+    let val = extensions.transform.get_tfield("m0").unwrap().collect::<Vec<_>>();
+    assert_eq!(val, &["foo"]);
+
+    let val = extensions.transform.get_tfield("x0").unwrap().collect::<Vec<_>>();
+    assert_eq!(val.is_empty(), true);
+
+    let val = extensions.transform.remove_tfield("m0").unwrap();
+    assert_eq!(val, true);
+    assert_parsed_locale_identifier("pl", &extensions);
+
     let mut extensions = ExtensionsMap::default();
     extensions.private.add_tag("testing").unwrap();
     assert_parsed_locale_identifier("und-x-testing", &extensions);

--- a/unic-locale/README.md
+++ b/unic-locale/README.md
@@ -20,6 +20,11 @@ assert_eq!(loc.get_region(), Some("US"));
 loc.extensions.unicode.set_keyword("ca", "buddhist")
     .expect("Setting extension failed.");
 
+let val = loc.extensions.unicode.get_keyword("ca")
+    .expect("Getting extension value failed.");
+
+assert_eq!(val, vec!["buddhist"]);
+
 assert_eq!(&loc.to_string(), "en-US-u-ca-buddhist-hc-h12");
 ```
 


### PR DESCRIPTION
* unicode: get_keyword, get_attribute, remove_keyword, remove_attribute
* transform: get_tfield, remove_tfield
* private: get_tag, remove_tag

I think I should probably add some documentation to these functions before merging so setting to WIP for now. I would like to hear whether this looks like the right way to go about doing this.

My questions:
* Normal Rust style seems to be remove-and-return from containers. I haven't done this here as we return `Vec<&strs>` from TinyStrs currently, we would have to copy the data out to return it as `Vec<str>` or `Vec<TinyStr>`.
* Is it sensible to return `Result<bool, LocaleError>` from `get_attribute` and similar fns or would it be better to return `Result<Option<()> LocaleError>`?
* I haven't done any tests on the private extensions yet. It looks like it currently is sorted but not deduped. I'm not sure of the semantics of private extensions. Is `-x-foo-foo` a canonical private use extension? Is `-x-zzz-aaa` or should it be `-x-aaa-zzz`? This is probably a question for a different time.
* Should unicode attributes be stored in a BTreeSet to avoid current manual sorting?
