### PR TITLE
Switch set_variants to use ExactSizeIterator

### DIFF
--- a/unic-langid-impl/Cargo.toml
+++ b/unic-langid-impl/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["internationalization"]
 exclude = ["data/*"]
 
 [dependencies]
-tinystr = "0.3"
+tinystr = { git = "https://github.com/zbraniecki/tinystr", branch = "u8" }
 serde = { version = "1.0", optional = true }
 serde_json = { version = "1.0", optional = true }
 

--- a/unic-langid-impl/benches/canonicalize.rs
+++ b/unic-langid-impl/benches/canonicalize.rs
@@ -1,3 +1,4 @@
+use criterion::black_box;
 use criterion::criterion_group;
 use criterion::criterion_main;
 use criterion::Criterion;
@@ -14,10 +15,18 @@ fn langid_canonicalize_bench(c: &mut Criterion) {
         "ZH_cyrl_hN",
         "eN-lAtN-uS",
     ];
-    c.bench_function("langid_canonicalize", move |b| {
+    c.bench_function("langid_canonicalize", |b| {
         b.iter(|| {
             for s in strings {
-                let _ = canonicalize(s);
+                let _ = canonicalize(black_box(s));
+            }
+        })
+    });
+    c.bench_function("langid_canonicalize_from_bytes", |b| {
+        let slices: Vec<&[u8]> = strings.iter().map(|s| s.as_bytes()).collect();
+        b.iter(|| {
+            for s in &slices {
+                let _ = canonicalize(black_box(s));
             }
         })
     });

--- a/unic-langid-impl/benches/langid.rs
+++ b/unic-langid-impl/benches/langid.rs
@@ -1,3 +1,4 @@
+use criterion::black_box;
 use criterion::criterion_group;
 use criterion::criterion_main;
 use criterion::Criterion;
@@ -33,7 +34,15 @@ fn language_identifier_construct_bench(c: &mut Criterion) {
         Fun::new("from_str", |b, _| {
             b.iter(|| {
                 for s in STRINGS {
-                    let _: Result<LanguageIdentifier, _> = s.parse();
+                    let _: Result<LanguageIdentifier, _> = black_box(s).parse();
+                }
+            })
+        }),
+        Fun::new("from_bytes", |b, _| {
+            let slices: Vec<&[u8]> = STRINGS.iter().map(|s| s.as_bytes()).collect();
+            b.iter(|| {
+                for s in &slices {
+                    let _ = LanguageIdentifier::from_bytes(black_box(s));
                 }
             })
         }),

--- a/unic-langid-impl/benches/langid.rs
+++ b/unic-langid-impl/benches/langid.rs
@@ -61,7 +61,7 @@ fn language_identifier_construct_bench(c: &mut Criterion) {
                         lang,
                         langid.get_script(),
                         langid.get_region(),
-                        langid.get_variants(),
+                        langid.get_variants().collect::<Vec<_>>(),
                     )
                 })
                 .collect();

--- a/unic-langid-impl/benches/parser.rs
+++ b/unic-langid-impl/benches/parser.rs
@@ -1,3 +1,4 @@
+use criterion::black_box;
 use criterion::criterion_group;
 use criterion::criterion_main;
 use criterion::Criterion;
@@ -21,10 +22,12 @@ fn language_identifier_parser_bench(c: &mut Criterion) {
         "mk",
         "uk",
     ];
-    c.bench_function("language_identifier_parser", move |b| {
+
+    c.bench_function("language_identifier_parser", |b| {
+        let slices: Vec<&[u8]> = strings.iter().map(|s| s.as_bytes()).collect();
         b.iter(|| {
-            for s in strings {
-                let _ = parse_language_identifier(s);
+            for s in &slices {
+                let _ = parse_language_identifier(black_box(s));
             }
         })
     });
@@ -47,10 +50,11 @@ fn language_identifier_parser_casing_bench(c: &mut Criterion) {
         "Mk",
         "uK",
     ];
-    c.bench_function("language_identifier_parser_casing", move |b| {
+    c.bench_function("language_identifier_parser_casing", |b| {
+        let slices: Vec<&[u8]> = strings.iter().map(|s| s.as_bytes()).collect();
         b.iter(|| {
-            for s in strings {
-                let _ = parse_language_identifier(s);
+            for s in &slices {
+                let _ = parse_language_identifier(black_box(s));
             }
         })
     });

--- a/unic-langid-impl/src/bin/generate_likelysubtags.rs
+++ b/unic-langid-impl/src/bin/generate_likelysubtags.rs
@@ -57,7 +57,7 @@ fn main() {
         let v: &str = v.as_str().unwrap();
         let mut value_langid: LanguageIdentifier = v.parse().expect("Failed to parse a value.");
         if let Some("ZZ") = value_langid.get_region() {
-            value_langid.set_region(None).unwrap();
+            value_langid.clear_region();
         }
         let (val_lang, val_script, val_region, _) = value_langid.into_raw_parts();
 

--- a/unic-langid-impl/src/lib.rs
+++ b/unic-langid-impl/src/lib.rs
@@ -306,17 +306,17 @@ impl LanguageIdentifier {
     /// let mut li: LanguageIdentifier = "de-Latn-AT".parse()
     ///     .expect("Parsing failed.");
     ///
-    /// li.set_language(Some("fr"));
+    /// li.set_language("fr");
     ///
     /// assert_eq!(li.to_string(), "fr-Latn-AT");
     /// ```
-    pub fn set_language(&mut self, language: Option<&str>) -> Result<(), LanguageIdentifierError> {
-        self.language = if let Some(lang) = language {
-            subtags::parse_language_subtag(lang)?
-        } else {
-            None
-        };
+    pub fn set_language(&mut self, language: &str) -> Result<(), LanguageIdentifierError> {
+        self.language = subtags::parse_language_subtag(language)?;
         Ok(())
+    }
+
+    pub fn clear_language(&mut self) {
+        self.language = None;
     }
 
     /// Returns the script subtag of the `LanguageIdentifier`, if set.
@@ -350,17 +350,17 @@ impl LanguageIdentifier {
     /// let mut li: LanguageIdentifier = "sr-Latn".parse()
     ///     .expect("Parsing failed.");
     ///
-    /// li.set_script(Some("Cyrl"));
+    /// li.set_script("Cyrl");
     ///
     /// assert_eq!(li.to_string(), "sr-Cyrl");
     /// ```
-    pub fn set_script(&mut self, script: Option<&str>) -> Result<(), LanguageIdentifierError> {
-        self.script = if let Some(script) = script {
-            Some(subtags::parse_script_subtag(script)?)
-        } else {
-            None
-        };
+    pub fn set_script(&mut self, script: &str) -> Result<(), LanguageIdentifierError> {
+        self.script = Some(subtags::parse_script_subtag(script)?);
         Ok(())
+    }
+
+    pub fn clear_script(&mut self) {
+        self.script = None;
     }
 
     /// Returns the region subtag of the `LanguageIdentifier`, if set.
@@ -394,17 +394,17 @@ impl LanguageIdentifier {
     /// let mut li: LanguageIdentifier = "fr-FR".parse()
     ///     .expect("Parsing failed.");
     ///
-    /// li.set_region(Some("CA"));
+    /// li.set_region("CA");
     ///
     /// assert_eq!(li.to_string(), "fr-CA");
     /// ```
-    pub fn set_region(&mut self, region: Option<&str>) -> Result<(), LanguageIdentifierError> {
-        self.region = if let Some(region) = region {
-            Some(subtags::parse_region_subtag(region)?)
-        } else {
-            None
-        };
+    pub fn set_region(&mut self, region: &str) -> Result<(), LanguageIdentifierError> {
+        self.region = Some(subtags::parse_region_subtag(region)?);
         Ok(())
+    }
+
+    pub fn clear_region(&mut self) {
+        self.region = None;
     }
 
     /// Returns a vector of variants subtags of the `LanguageIdentifier`.
@@ -459,6 +459,10 @@ impl LanguageIdentifier {
             self.variants = Some(result.into_boxed_slice());
         }
         Ok(())
+    }
+
+    pub fn clear_variants(&mut self) {
+        self.variants = None;
     }
 
     /// Extends the `LanguageIdentifier` adding likely subtags based

--- a/unic-langid-impl/src/parser/mod.rs
+++ b/unic-langid-impl/src/parser/mod.rs
@@ -6,10 +6,8 @@ pub use self::errors::ParserError;
 use crate::subtags;
 use crate::LanguageIdentifier;
 
-static SEPARATORS: &[char] = &['-', '_'];
-
 pub fn parse_language_identifier_from_iter<'a>(
-    iter: &mut Peekable<impl Iterator<Item = &'a str>>,
+    iter: &mut Peekable<impl Iterator<Item = &'a [u8]>>,
     allow_extension: bool,
 ) -> Result<LanguageIdentifier, ParserError> {
     let mut position = 0;
@@ -73,7 +71,7 @@ pub fn parse_language_identifier_from_iter<'a>(
     })
 }
 
-pub fn parse_language_identifier(t: &str) -> Result<LanguageIdentifier, ParserError> {
-    let mut iter = t.split(|c| SEPARATORS.contains(&c)).peekable();
+pub fn parse_language_identifier(t: &[u8]) -> Result<LanguageIdentifier, ParserError> {
+    let mut iter = t.split(|c| *c == b'-' || *c == b'_').peekable();
     parse_language_identifier_from_iter(&mut iter, false)
 }

--- a/unic-langid-impl/src/subtags.rs
+++ b/unic-langid-impl/src/subtags.rs
@@ -1,10 +1,10 @@
 use crate::parser::errors::ParserError;
 use tinystr::{TinyStr4, TinyStr8};
 
-pub fn parse_language_subtag(subtag: &str) -> Result<Option<TinyStr8>, ParserError> {
+pub fn parse_language_subtag(subtag: &[u8]) -> Result<Option<TinyStr8>, ParserError> {
     let slen = subtag.len();
 
-    let s: TinyStr8 = subtag.parse().map_err(|_| ParserError::InvalidLanguage)?;
+    let s = TinyStr8::from_bytes(subtag).map_err(|_| ParserError::InvalidLanguage)?;
     if slen < 2 || slen > 8 || slen == 4 || !s.is_ascii_alphabetic() {
         return Err(ParserError::InvalidLanguage);
     }
@@ -18,56 +18,54 @@ pub fn parse_language_subtag(subtag: &str) -> Result<Option<TinyStr8>, ParserErr
     }
 }
 
-pub fn parse_script_subtag(subtag: &str) -> Result<TinyStr4, ParserError> {
+pub fn parse_script_subtag(subtag: &[u8]) -> Result<TinyStr4, ParserError> {
     let slen = subtag.len();
 
-    let s: TinyStr4 = subtag.parse().map_err(|_| ParserError::InvalidSubtag)?;
+    let s = TinyStr4::from_bytes(subtag).map_err(|_| ParserError::InvalidSubtag)?;
     if slen != 4 || !s.is_ascii_alphabetic() {
         return Err(ParserError::InvalidSubtag);
     }
     Ok(s.to_ascii_titlecase())
 }
 
-pub fn parse_region_subtag(subtag: &str) -> Result<TinyStr4, ParserError> {
+pub fn parse_region_subtag(subtag: &[u8]) -> Result<TinyStr4, ParserError> {
     let slen = subtag.len();
 
     match slen {
         2 => {
-            let s: TinyStr4 = subtag.parse().map_err(|_| ParserError::InvalidSubtag)?;
+            let s = TinyStr4::from_bytes(subtag).map_err(|_| ParserError::InvalidSubtag)?;
             if !s.is_ascii_alphabetic() {
                 return Err(ParserError::InvalidSubtag);
             }
             Ok(s.to_ascii_uppercase())
         }
         3 => {
-            if subtag.contains(|c: char| !c.is_ascii_digit()) {
+            let s = TinyStr4::from_bytes(subtag).map_err(|_| ParserError::InvalidSubtag)?;
+            if !s.is_ascii_numeric() {
                 return Err(ParserError::InvalidSubtag);
             }
-            Ok(subtag.parse().unwrap())
+            Ok(s)
         }
         _ => Err(ParserError::InvalidSubtag),
     }
 }
 
-pub fn parse_variant_subtag(subtag: &str) -> Result<TinyStr8, ParserError> {
+pub fn parse_variant_subtag(subtag: &[u8]) -> Result<TinyStr8, ParserError> {
     let slen = subtag.len();
 
     if slen < 4 || slen > 8 {
         return Err(ParserError::InvalidSubtag);
     }
 
-    if slen >= 5 && subtag.contains(|c: char| !c.is_ascii_alphanumeric()) {
-        return Err(ParserError::InvalidSubtag);
-    }
+    let s = TinyStr8::from_bytes(subtag).unwrap();
 
-    if slen == 4
-        && !subtag.as_bytes()[0].is_ascii_digit()
-        && subtag[1..].contains(|c: char| !c.is_ascii_alphanumeric())
+    if (slen >= 5 && !s.is_ascii_alphanumeric())
+        || (slen == 4
+            && !subtag[0].is_ascii_digit()
+            && subtag[1..].iter().any(|c: &u8| !c.is_ascii_alphanumeric()))
     {
         return Err(ParserError::InvalidSubtag);
     }
-
-    let s: TinyStr8 = subtag.parse().unwrap();
 
     Ok(s.to_ascii_lowercase())
 }

--- a/unic-langid-impl/tests/language_identifier_test.rs
+++ b/unic-langid-impl/tests/language_identifier_test.rs
@@ -104,35 +104,27 @@ fn test_set_fields() {
     let mut langid = LanguageIdentifier::default();
     assert_eq!(&langid.to_string(), "und");
 
-    langid
-        .set_language(Some("pl"))
-        .expect("Setting language failed");
+    langid.set_language("pl").expect("Setting language failed");
     assert_eq!(&langid.to_string(), "pl");
 
-    langid
-        .set_language(Some("de"))
-        .expect("Setting language failed");
+    langid.set_language("de").expect("Setting language failed");
     assert_eq!(&langid.to_string(), "de");
-    langid
-        .set_region(Some("AT"))
-        .expect("Setting region failed");
+    langid.set_region("AT").expect("Setting region failed");
     assert_eq!(&langid.to_string(), "de-AT");
-    langid
-        .set_script(Some("Latn"))
-        .expect("Setting script failed");
+    langid.set_script("Latn").expect("Setting script failed");
     assert_eq!(&langid.to_string(), "de-Latn-AT");
     langid
         .set_variants(&["macos"])
         .expect("Setting variants failed");
     assert_eq!(&langid.to_string(), "de-Latn-AT-macos");
 
-    langid.set_language(None).expect("Setting language failed");
+    langid.clear_language();
     assert_eq!(&langid.to_string(), "und-Latn-AT-macos");
-    langid.set_region(None).expect("Setting region failed");
+    langid.clear_region();
     assert_eq!(&langid.to_string(), "und-Latn-macos");
-    langid.set_script(None).expect("Setting script failed");
+    langid.clear_script();
     assert_eq!(&langid.to_string(), "und-macos");
-    langid.set_variants(&[]).expect("Setting variants failed");
+    langid.clear_variants();
     assert_eq!(&langid.to_string(), "und");
 }
 

--- a/unic-langid-impl/tests/language_identifier_test.rs
+++ b/unic-langid-impl/tests/language_identifier_test.rs
@@ -24,7 +24,7 @@ fn assert_parsed_language_identifier(
     region: Option<&str>,
     variants: Option<&[&str]>,
 ) {
-    let langid = parse_language_identifier(input).unwrap();
+    let langid = parse_language_identifier(input.as_bytes()).unwrap();
     assert_language_identifier(&langid, language, script, region, variants);
 }
 

--- a/unic-langid-impl/tests/language_identifier_test.rs
+++ b/unic-langid-impl/tests/language_identifier_test.rs
@@ -14,7 +14,10 @@ fn assert_language_identifier(
     assert_eq!(loc.get_language(), language.unwrap_or("und"));
     assert_eq!(loc.get_script(), script);
     assert_eq!(loc.get_region(), region);
-    assert_eq!(loc.get_variants(), variants.unwrap_or(&[]));
+    assert_eq!(
+        loc.get_variants().collect::<Vec<_>>(),
+        variants.unwrap_or(&[])
+    );
 }
 
 fn assert_parsed_language_identifier(

--- a/unic-langid-macros-impl/Cargo.toml
+++ b/unic-langid-macros-impl/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["internationalization"]
 proc_macro = true
 
 [dependencies]
-unic-langid-impl = "0.6"
+unic-langid-impl = { path = "../unic-langid-impl" }
 syn = "1.0"
 quote = "1.0"
 proc-macro-hack = "0.5"

--- a/unic-langid-macros/Cargo.toml
+++ b/unic-langid-macros/Cargo.toml
@@ -11,6 +11,6 @@ categories = ["internationalization"]
 
 [dependencies]
 proc-macro-hack = "0.5"
-unic-langid-macros-impl = "0.6"
-unic-langid-impl = "0.6"
-tinystr = "0.3"
+unic-langid-macros-impl = { path = "../unic-langid-macros-impl" }
+unic-langid-impl = { path = "../unic-langid-impl" }
+tinystr = { git = "https://github.com/zbraniecki/tinystr", branch = "u8" }

--- a/unic-langid/Cargo.toml
+++ b/unic-langid/Cargo.toml
@@ -10,11 +10,11 @@ license = "MIT/Apache-2.0"
 categories = ["internationalization"]
 
 [dependencies]
-unic-langid-impl = "0.6"
-unic-langid-macros = { version = "0.6", optional = true }
+unic-langid-impl = { path = "../unic-langid-impl" }
+unic-langid-macros = { path = "../unic-langid-macros", optional = true }
 
 [dev-dependencies]
-unic-langid-macros = "0.6"
+unic-langid-macros = { path = "../unic-langid-macros" }
 
 [features]
 default = []

--- a/unic-langid/src/lib.rs
+++ b/unic-langid/src/lib.rs
@@ -17,7 +17,7 @@
 //! assert_eq!(li.get_region(), Some("US"));
 //! assert_eq!(li.get_variants().len(), 0);
 //!
-//! li.set_region(Some("GB"))
+//! li.set_region("GB")
 //!     .expect("Region parsing failed.");
 //!
 //! assert_eq!(li.to_string(), "en-GB");

--- a/unic-locale-impl/Cargo.toml
+++ b/unic-locale-impl/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["internationalization"]
 
 [dependencies]
 unic-langid-impl = { path = "../unic-langid-impl" }
-tinystr = "0.3"
+tinystr = { git = "https://github.com/zbraniecki/tinystr", branch = "u8" }
 
 [dev-dependencies]
 criterion = "0.3"

--- a/unic-locale-impl/Cargo.toml
+++ b/unic-locale-impl/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT/Apache-2.0"
 categories = ["internationalization"]
 
 [dependencies]
-unic-langid-impl = "0.6"
+unic-langid-impl = { path = "../unic-langid-impl" }
 tinystr = "0.3"
 
 [dev-dependencies]

--- a/unic-locale-impl/src/extensions/private.rs
+++ b/unic-locale-impl/src/extensions/private.rs
@@ -6,8 +6,8 @@ use tinystr::TinyStr8;
 #[derive(Clone, PartialEq, Eq, Debug, Default)]
 pub struct PrivateExtensionList(Vec<TinyStr8>);
 
-fn parse_value(t: &str) -> Result<TinyStr8, ParserError> {
-    let s: TinyStr8 = t.parse().map_err(|_| ParserError::InvalidSubtag)?;
+fn parse_value(t: &[u8]) -> Result<TinyStr8, ParserError> {
+    let s = TinyStr8::from_bytes(t).map_err(|_| ParserError::InvalidSubtag)?;
     if t.is_empty() || t.len() > 8 || !s.is_ascii_alphanumeric() {
         return Err(ParserError::InvalidSubtag);
     }
@@ -20,14 +20,14 @@ impl PrivateExtensionList {
         self.0.is_empty()
     }
 
-    pub fn add_tag(&mut self, tag: &str) -> Result<(), LocaleError> {
-        self.0.push(parse_value(tag)?);
+    pub fn add_tag<S: AsRef<[u8]>>(&mut self, tag: S) -> Result<(), LocaleError> {
+        self.0.push(parse_value(tag.as_ref())?);
         self.0.sort();
         Ok(())
     }
 
-    pub fn try_from_iter<'a>(
-        iter: &mut impl Iterator<Item = &'a str>,
+    pub(crate) fn try_from_iter<'a>(
+        iter: &mut impl Iterator<Item = &'a [u8]>,
     ) -> Result<Self, ParserError> {
         let mut pext = Self::default();
 

--- a/unic-locale-impl/src/extensions/transform.rs
+++ b/unic-locale-impl/src/extensions/transform.rs
@@ -56,11 +56,7 @@ impl TransformExtensionList {
         Ok(())
     }
 
-    pub fn set_tfield<S: AsRef<[u8]>>(
-        &mut self,
-        tkey: S,
-        tvalue: &[S],
-    ) -> Result<(), LocaleError> {
+    pub fn set_tfield<S: AsRef<[u8]>>(&mut self, tkey: S, tvalue: &[S]) -> Result<(), LocaleError> {
         let tkey = parse_tkey(tkey.as_ref())?;
         let mut t = Vec::with_capacity(tvalue.len());
         for val in tvalue {

--- a/unic-locale-impl/src/extensions/unicode.rs
+++ b/unic-locale-impl/src/extensions/unicode.rs
@@ -64,11 +64,7 @@ impl UnicodeExtensionList {
         self.keywords.is_empty() && self.attributes.is_empty()
     }
 
-    pub fn set_keyword<S: AsRef<[u8]>>(
-        &mut self,
-        key: S,
-        value: &[S],
-    ) -> Result<(), LocaleError> {
+    pub fn set_keyword<S: AsRef<[u8]>>(&mut self, key: S, value: &[S]) -> Result<(), LocaleError> {
         let key = parse_key(key.as_ref())?;
 
         let mut t = Vec::with_capacity(value.len());

--- a/unic-locale-impl/src/lib.rs
+++ b/unic-locale-impl/src/lib.rs
@@ -74,30 +74,42 @@ impl Locale {
         self.langid.get_language()
     }
 
-    pub fn set_language(&mut self, language: Option<&str>) -> Result<(), LocaleError> {
+    pub fn set_language(&mut self, language: &str) -> Result<(), LocaleError> {
         self.langid
             .set_language(language)
             .map_err(std::convert::Into::into)
+    }
+
+    pub fn clear_language(&mut self) {
+        self.langid.clear_language()
     }
 
     pub fn get_script(&self) -> Option<&str> {
         self.langid.get_script()
     }
 
-    pub fn set_script(&mut self, script: Option<&str>) -> Result<(), LocaleError> {
+    pub fn set_script(&mut self, script: &str) -> Result<(), LocaleError> {
         self.langid
             .set_script(script)
             .map_err(std::convert::Into::into)
+    }
+
+    pub fn clear_script(&mut self) {
+        self.langid.clear_script()
     }
 
     pub fn get_region(&self) -> Option<&str> {
         self.langid.get_region()
     }
 
-    pub fn set_region(&mut self, region: Option<&str>) -> Result<(), LocaleError> {
+    pub fn set_region(&mut self, region: &str) -> Result<(), LocaleError> {
         self.langid
             .set_region(region)
             .map_err(std::convert::Into::into)
+    }
+
+    pub fn clear_region(&mut self) {
+        self.langid.clear_region()
     }
 
     pub fn get_variants(&self) -> Vec<&str> {
@@ -108,6 +120,10 @@ impl Locale {
         self.langid
             .set_variants(variants)
             .map_err(std::convert::Into::into)
+    }
+
+    pub fn clear_variants(&mut self) {
+        self.langid.clear_variants()
     }
 
     #[cfg(feature = "likelysubtags")]

--- a/unic-locale-impl/src/lib.rs
+++ b/unic-locale-impl/src/lib.rs
@@ -25,7 +25,7 @@ type RawPartsTuple = (
 
 impl Locale {
     pub fn from_bytes(v: &[u8]) -> Result<Self, LocaleError> {
-        parser::parse_locale(v).map_err(std::convert::Into::into)
+        Ok(parser::parse_locale(v)?)
     }
 
     pub fn from_parts<S: AsRef<[u8]>>(
@@ -79,9 +79,7 @@ impl Locale {
     }
 
     pub fn set_language<S: AsRef<[u8]>>(&mut self, language: S) -> Result<(), LocaleError> {
-        self.langid
-            .set_language(language)
-            .map_err(std::convert::Into::into)
+        Ok(self.langid.set_language(language)?)
     }
 
     pub fn clear_language(&mut self) {
@@ -93,9 +91,7 @@ impl Locale {
     }
 
     pub fn set_script<S: AsRef<[u8]>>(&mut self, script: S) -> Result<(), LocaleError> {
-        self.langid
-            .set_script(script)
-            .map_err(std::convert::Into::into)
+        Ok(self.langid.set_script(script)?)
     }
 
     pub fn clear_script(&mut self) {
@@ -107,23 +103,22 @@ impl Locale {
     }
 
     pub fn set_region<S: AsRef<[u8]>>(&mut self, region: S) -> Result<(), LocaleError> {
-        self.langid
-            .set_region(region)
-            .map_err(std::convert::Into::into)
+        Ok(self.langid.set_region(region)?)
     }
 
     pub fn clear_region(&mut self) {
         self.langid.clear_region()
     }
 
-    pub fn get_variants(&self) -> Vec<&str> {
+    pub fn get_variants(&self) -> impl ExactSizeIterator<Item = &str> {
         self.langid.get_variants()
     }
 
-    pub fn set_variants<S: AsRef<[u8]>>(&mut self, variants: &[S]) -> Result<(), LocaleError> {
-        self.langid
-            .set_variants(variants)
-            .map_err(std::convert::Into::into)
+    pub fn set_variants<S: AsRef<[u8]>>(
+        &mut self,
+        variants: impl IntoIterator<Item = S>,
+    ) -> Result<(), LocaleError> {
+        Ok(self.langid.set_variants(variants)?)
     }
 
     pub fn clear_variants(&mut self) {
@@ -149,7 +144,7 @@ impl FromStr for Locale {
     type Err = LocaleError;
 
     fn from_str(source: &str) -> Result<Self, Self::Err> {
-        parser::parse_locale(source).map_err(std::convert::Into::into)
+        Ok(parser::parse_locale(source)?)
     }
 }
 

--- a/unic-locale-impl/src/lib.rs
+++ b/unic-locale-impl/src/lib.rs
@@ -24,7 +24,11 @@ type RawPartsTuple = (
 );
 
 impl Locale {
-    pub fn from_parts<S: AsRef<str>>(
+    pub fn from_bytes(v: &[u8]) -> Result<Self, LocaleError> {
+        parser::parse_locale(v).map_err(std::convert::Into::into)
+    }
+
+    pub fn from_parts<S: AsRef<[u8]>>(
         language: Option<S>,
         script: Option<S>,
         region: Option<S>,
@@ -74,7 +78,7 @@ impl Locale {
         self.langid.get_language()
     }
 
-    pub fn set_language(&mut self, language: &str) -> Result<(), LocaleError> {
+    pub fn set_language<S: AsRef<[u8]>>(&mut self, language: S) -> Result<(), LocaleError> {
         self.langid
             .set_language(language)
             .map_err(std::convert::Into::into)
@@ -88,7 +92,7 @@ impl Locale {
         self.langid.get_script()
     }
 
-    pub fn set_script(&mut self, script: &str) -> Result<(), LocaleError> {
+    pub fn set_script<S: AsRef<[u8]>>(&mut self, script: S) -> Result<(), LocaleError> {
         self.langid
             .set_script(script)
             .map_err(std::convert::Into::into)
@@ -102,7 +106,7 @@ impl Locale {
         self.langid.get_region()
     }
 
-    pub fn set_region(&mut self, region: &str) -> Result<(), LocaleError> {
+    pub fn set_region<S: AsRef<[u8]>>(&mut self, region: S) -> Result<(), LocaleError> {
         self.langid
             .set_region(region)
             .map_err(std::convert::Into::into)
@@ -116,7 +120,7 @@ impl Locale {
         self.langid.get_variants()
     }
 
-    pub fn set_variants(&mut self, variants: &[&str]) -> Result<(), LocaleError> {
+    pub fn set_variants<S: AsRef<[u8]>>(&mut self, variants: &[S]) -> Result<(), LocaleError> {
         self.langid
             .set_variants(variants)
             .map_err(std::convert::Into::into)
@@ -183,7 +187,7 @@ impl std::fmt::Display for Locale {
     }
 }
 
-pub fn canonicalize(input: &str) -> Result<String, LocaleError> {
-    let locale: Locale = input.parse()?;
+pub fn canonicalize<S: AsRef<[u8]>>(input: S) -> Result<String, LocaleError> {
+    let locale = Locale::from_bytes(input.as_ref())?;
     Ok(locale.to_string())
 }

--- a/unic-locale-impl/src/parser/mod.rs
+++ b/unic-locale-impl/src/parser/mod.rs
@@ -5,10 +5,8 @@ use super::extensions::ExtensionsMap;
 use super::Locale;
 use unic_langid_impl::LanguageIdentifier;
 
-static SEPARATORS: &[char] = &['-', '_'];
-
-pub fn parse_locale(t: &str) -> Result<Locale, ParserError> {
-    let mut iter = t.split(|c| SEPARATORS.contains(&c)).peekable();
+pub fn parse_locale<S: AsRef<[u8]>>(t: S) -> Result<Locale, ParserError> {
+    let mut iter = t.as_ref().split(|c| *c == b'-' || *c == b'_').peekable();
 
     let langid = LanguageIdentifier::try_from_iter(&mut iter, true)
         .map_err(|_| ParserError::InvalidLanguage)?;

--- a/unic-locale-impl/tests/fixtures.rs
+++ b/unic-locale-impl/tests/fixtures.rs
@@ -46,14 +46,14 @@ fn read_locale_testsets<P: AsRef<Path>>(path: P) -> Result<Vec<LocaleTestSet>, B
 fn create_extensions_map(map: HashMap<String, HashMap<String, String>>) -> ExtensionsMap {
     let mut result = ExtensionsMap::default();
     for (key, map) in map {
-        let t: ExtensionType = ExtensionType::from_char(key.chars().nth(0).unwrap())
+        let t: ExtensionType = ExtensionType::from_byte(key.chars().nth(0).unwrap() as u8)
             .expect("Failed to format extension type.");
         match t {
             ExtensionType::Unicode => {
                 for (key, value) in map {
                     result
                         .unicode
-                        .set_keyword(&key, vec![value.as_str()])
+                        .set_keyword(&key, vec![&value])
                         .expect("Setting extension value failed.");
                 }
             }
@@ -95,7 +95,7 @@ fn test_locale_fixtures(path: &str) {
                     locale
                         .extensions
                         .unicode
-                        .set_keyword(&key, vec![value.as_str()])
+                        .set_keyword(&key, vec![&value])
                         .expect("Failed to set extension value.");
                 }
             }

--- a/unic-locale-impl/tests/fixtures.rs
+++ b/unic-locale-impl/tests/fixtures.rs
@@ -53,7 +53,7 @@ fn create_extensions_map(map: HashMap<String, HashMap<String, String>>) -> Exten
                 for (key, value) in map {
                     result
                         .unicode
-                        .set_keyword(&key, vec![&value])
+                        .set_keyword(&key, &[&value])
                         .expect("Setting extension value failed.");
                 }
             }
@@ -95,7 +95,7 @@ fn test_locale_fixtures(path: &str) {
                     locale
                         .extensions
                         .unicode
-                        .set_keyword(&key, vec![&value])
+                        .set_keyword(&key, &[&value])
                         .expect("Failed to set extension value.");
                 }
             }

--- a/unic-locale-impl/tests/locale_test.rs
+++ b/unic-locale-impl/tests/locale_test.rs
@@ -105,28 +105,26 @@ fn test_set_fields() {
     let mut loc = Locale::default();
     assert_eq!(&loc.to_string(), "und");
 
-    loc.set_language(Some("pl"))
-        .expect("Setting language failed");
+    loc.set_language("pl").expect("Setting language failed");
     assert_eq!(&loc.to_string(), "pl");
 
-    loc.set_language(Some("de"))
-        .expect("Setting language failed");
+    loc.set_language("de").expect("Setting language failed");
     assert_eq!(&loc.to_string(), "de");
-    loc.set_region(Some("AT")).expect("Setting region failed");
+    loc.set_region("AT").expect("Setting region failed");
     assert_eq!(&loc.to_string(), "de-AT");
-    loc.set_script(Some("Latn")).expect("Setting script failed");
+    loc.set_script("Latn").expect("Setting script failed");
     assert_eq!(&loc.to_string(), "de-Latn-AT");
     loc.set_variants(&["macos"])
         .expect("Setting variants failed");
     assert_eq!(&loc.to_string(), "de-Latn-AT-macos");
 
-    loc.set_language(None).expect("Setting language failed");
+    loc.clear_language();
     assert_eq!(&loc.to_string(), "und-Latn-AT-macos");
-    loc.set_region(None).expect("Setting region failed");
+    loc.clear_region();
     assert_eq!(&loc.to_string(), "und-Latn-macos");
-    loc.set_script(None).expect("Setting script failed");
+    loc.clear_script();
     assert_eq!(&loc.to_string(), "und-macos");
-    loc.set_variants(&[]).expect("Setting variants failed");
+    loc.clear_variants();
     assert_eq!(&loc.to_string(), "und");
 }
 

--- a/unic-locale-impl/tests/locale_test.rs
+++ b/unic-locale-impl/tests/locale_test.rs
@@ -37,7 +37,7 @@ fn test_from_parts() {
 #[test]
 fn test_locale_identifier() {
     let mut extensions = ExtensionsMap::default();
-    extensions.unicode.set_keyword("hc", vec!["h12"]).unwrap();
+    extensions.unicode.set_keyword("hc", &["h12"]).unwrap();
     assert_parsed_locale_identifier("pl-u-hc-h12", &extensions);
 
     let mut extensions = ExtensionsMap::default();

--- a/unic-locale-macros-impl/Cargo.toml
+++ b/unic-locale-macros-impl/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["internationalization"]
 proc_macro = true
 
 [dependencies]
-unic-locale-impl = "0.6"
+unic-locale-impl = { path = "../unic-locale-impl" }
 syn = "1.0"
 quote = "1.0"
 proc-macro-hack = "0.5"

--- a/unic-locale-macros/Cargo.toml
+++ b/unic-locale-macros/Cargo.toml
@@ -11,6 +11,6 @@ categories = ["internationalization"]
 
 [dependencies]
 proc-macro-hack = "0.5"
-tinystr = "0.3"
-unic-locale-macros-impl = "0.6"
-unic-locale-impl = "0.6"
+tinystr = { git = "https://github.com/zbraniecki/tinystr", branch = "u8" }
+unic-locale-macros-impl = { path = "../unic-locale-macros-impl" }
+unic-locale-impl = { path = "../unic-locale-impl" }

--- a/unic-locale/Cargo.toml
+++ b/unic-locale/Cargo.toml
@@ -10,12 +10,12 @@ license = "MIT/Apache-2.0"
 categories = ["internationalization"]
 
 [dependencies]
-unic-langid-impl = "0.6"
-unic-locale-impl = "0.6"
-unic-locale-macros = { version = "0.6", optional = true }
+unic-langid-impl = { path = "../unic-langid-impl" }
+unic-locale-impl = { path = "../unic-locale-impl" }
+unic-locale-macros = { path = "../unic-locale-macros" , optional = true }
 
 [dev-dependencies]
-unic-locale-macros = "0.6"
+unic-locale-macros = { path = "../unic-locale-macros" }
 
 [features]
 default = []

--- a/unic-locale/examples/simple-locale.rs
+++ b/unic-locale/examples/simple-locale.rs
@@ -7,7 +7,7 @@ fn main() {
     locale
         .extensions
         .unicode
-        .set_keyword("ca", vec!["buddhist"])
+        .set_keyword("ca", &["buddhist"])
         .expect("Setting extension failed.");
 
     println!("{:#?}", locale);


### PR DESCRIPTION
Per https://phabricator.services.mozilla.com/D49668 request, switching `set_variants` to use an iterator.

It's a bit weird from an API perspective to use `["foo"].iter()` instead of `&["foo"]` but that may be just because I'm used to the former?