### PR TITLE
Add Ord and PartialOrd

### DIFF
--- a/unic-langid-impl/src/lib.rs
+++ b/unic-langid-impl/src/lib.rs
@@ -27,12 +27,7 @@ pub enum CharacterDirection {
     LTR,
 }
 
-type RawPartsTuple = (
-    Option<u64>,
-    Option<u32>,
-    Option<u32>,
-    Option<Box<[u64]>>,
-);
+type RawPartsTuple = (Option<u64>, Option<u32>, Option<u32>, Option<Box<[u64]>>);
 
 /// `LanguageIdentifier` is a core struct representing a Unicode Language Identifier.
 ///
@@ -77,7 +72,7 @@ type RawPartsTuple = (
 /// assert_eq!(li.get_region(), Some("US"));
 /// assert_eq!(li.get_variants().collect::<Vec<_>>(), &["valencia"]);
 /// ```
-#[derive(Default, Debug, PartialEq, Eq, Clone, Hash)]
+#[derive(Default, Debug, PartialEq, Eq, Clone, Hash, PartialOrd, Ord)]
 pub struct LanguageIdentifier {
     language: Option<TinyStr8>,
     script: Option<TinyStr4>,

--- a/unic-langid-impl/tests/language_identifier_test.rs
+++ b/unic-langid-impl/tests/language_identifier_test.rs
@@ -153,3 +153,42 @@ fn test_character_direction() {
     assert_eq!(langid.get_character_direction(), CharacterDirection::LTR);
     assert_eq!(langid2.get_character_direction(), CharacterDirection::RTL);
 }
+
+#[test]
+fn test_langid_ord() {
+    let input = &[
+        "en-US-macos-zarab",
+        "en-US-macos-nedis",
+        "en-US-macos",
+        "en-GB",
+        "en",
+        "en-US",
+        "ar",
+        "fr",
+        "de",
+    ];
+
+    let mut langids = input
+        .iter()
+        .map(|l| -> LanguageIdentifier { l.parse().unwrap() })
+        .collect::<Vec<_>>();
+
+    langids.sort();
+
+    let result = langids.iter().map(|l| l.to_string()).collect::<Vec<_>>();
+
+    assert_eq!(
+        &result,
+        &[
+            "ar",
+            "de",
+            "en",
+            "en-GB",
+            "en-US",
+            "en-US-macos",
+            "en-US-macos-nedis",
+            "en-US-macos-zarab",
+            "fr"
+        ]
+    );
+}

--- a/unic-langid-macros-impl/Cargo.toml
+++ b/unic-langid-macros-impl/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["internationalization"]
 proc_macro = true
 
 [dependencies]
-unic-langid-impl = "0.7"
+unic-langid-impl = { path = "../unic-langid-impl" }
 syn = "1.0"
 quote = "1.0"
 proc-macro-hack = "0.5"

--- a/unic-langid-macros/Cargo.toml
+++ b/unic-langid-macros/Cargo.toml
@@ -11,6 +11,6 @@ categories = ["internationalization"]
 
 [dependencies]
 proc-macro-hack = "0.5"
-unic-langid-macros-impl = "0.7"
-unic-langid-impl = "0.7"
+unic-langid-macros-impl = { path = "../unic-langid-macros-impl" }
+unic-langid-impl = { path = "../unic-langid-impl" }
 tinystr = "0.3.2"

--- a/unic-langid/Cargo.toml
+++ b/unic-langid/Cargo.toml
@@ -10,11 +10,11 @@ license = "MIT/Apache-2.0"
 categories = ["internationalization"]
 
 [dependencies]
-unic-langid-impl = "0.7"
-unic-langid-macros = { version = "0.7", optional = true }
+unic-langid-impl = { path = "../unic-langid-impl" }
+unic-langid-macros = { path = "../unic-langid-macros", optional = true }
 
 [dev-dependencies]
-unic-langid-macros = "0.7"
+unic-langid-macros = { path = "../unic-langid-macros" }
 
 [features]
 default = []

--- a/unic-locale-impl/Cargo.toml
+++ b/unic-locale-impl/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT/Apache-2.0"
 categories = ["internationalization"]
 
 [dependencies]
-unic-langid-impl = "0.7"
+unic-langid-impl = { path = "../unic-langid-impl" }
 tinystr = "0.3.2"
 
 [dev-dependencies]

--- a/unic-locale-impl/src/extensions/mod.rs
+++ b/unic-locale-impl/src/extensions/mod.rs
@@ -25,16 +25,16 @@ use tinystr::TinyStr8;
 use crate::parser::ParserError;
 
 /// Defines the type of extension.
-#[derive(PartialEq, Eq, Debug, Clone, Copy, Hash)]
+#[derive(PartialEq, Eq, Debug, Clone, Copy, Hash, PartialOrd, Ord)]
 pub enum ExtensionType {
-    /// Unicode Extension Type marked as `u`.
-    Unicode,
     /// Transform Extension Type marked as `t`.
     Transform,
-    /// Other Extension Type marked as `a-z` except of `t`, `u` and `x`.
-    Other(char),
+    /// Unicode Extension Type marked as `u`.
+    Unicode,
     /// Private Extension Type marked as `x`.
     Private,
+    /// Other Extension Type marked as `a-z` except of `t`, `u` and `x`.
+    Other(char),
 }
 
 impl ExtensionType {
@@ -63,7 +63,7 @@ impl std::fmt::Display for ExtensionType {
 }
 
 /// A map of extensions associated with a given `Locale.
-#[derive(Debug, Default, PartialEq, Eq, Clone, Hash)]
+#[derive(Debug, Default, PartialEq, Eq, Clone, Hash, PartialOrd, Ord)]
 pub struct ExtensionsMap {
     pub unicode: UnicodeExtensionList,
     pub transform: TransformExtensionList,

--- a/unic-locale-impl/src/extensions/private.rs
+++ b/unic-locale-impl/src/extensions/private.rs
@@ -24,7 +24,7 @@ use tinystr::TinyStr8;
 ///
 /// [`Unicode Private Extensions`]: https://unicode.org/reports/tr35/#pu_extensions
 /// [`Unicode Locale Identifier`]: https://unicode.org/reports/tr35/#Unicode_locale_identifier
-#[derive(Clone, PartialEq, Eq, Debug, Default, Hash)]
+#[derive(Clone, PartialEq, Eq, Debug, Default, Hash, PartialOrd, Ord)]
 pub struct PrivateExtensionList(Vec<TinyStr8>);
 
 fn parse_value(t: &[u8]) -> Result<TinyStr8, ParserError> {

--- a/unic-locale-impl/src/extensions/transform.rs
+++ b/unic-locale-impl/src/extensions/transform.rs
@@ -37,7 +37,7 @@ use tinystr::{TinyStr4, TinyStr8};
 /// [`Unicode BCP47 T Extensions`]: https://unicode.org/reports/tr35/#t_Extension
 /// [`RFC 6497`]: https://www.ietf.org/rfc/rfc6497.txt
 /// [`Unicode Locale Identifier`]: https://unicode.org/reports/tr35/#Unicode_locale_identifier
-#[derive(Clone, PartialEq, Eq, Debug, Default, Hash)]
+#[derive(Clone, PartialEq, Eq, Debug, Default, Hash, PartialOrd, Ord)]
 pub struct TransformExtensionList {
     tlang: Option<LanguageIdentifier>,
 

--- a/unic-locale-impl/src/extensions/unicode.rs
+++ b/unic-locale-impl/src/extensions/unicode.rs
@@ -29,7 +29,7 @@ use tinystr::{TinyStr4, TinyStr8};
 /// [`Unicode BCP47 U Extensions`]: https://unicode.org/reports/tr35/#u_Extension
 /// [`RFC 6067`]: https://www.ietf.org/rfc/rfc6067.txt
 /// [`Unicode Locale Identifier`]: https://unicode.org/reports/tr35/#Unicode_locale_identifier
-#[derive(Clone, PartialEq, Eq, Debug, Default, Hash)]
+#[derive(Clone, PartialEq, Eq, Debug, Default, Hash, PartialOrd, Ord)]
 pub struct UnicodeExtensionList {
     // Canonical: sort by key (BTreeMap is already) / remove value 'true'
     keywords: BTreeMap<TinyStr4, Vec<TinyStr8>>,

--- a/unic-locale-impl/src/lib.rs
+++ b/unic-locale-impl/src/lib.rs
@@ -64,7 +64,7 @@ pub use unic_langid_impl::LanguageIdentifier;
 /// assert_eq!(loc.get_region(), Some("US"));
 /// assert_eq!(loc.get_variants().collect::<Vec<_>>(), &["valencia"]);
 /// ```
-#[derive(Debug, Default, PartialEq, Eq, Clone, Hash)]
+#[derive(Debug, Default, PartialEq, Eq, Clone, Hash, PartialOrd, Ord)]
 pub struct Locale {
     pub langid: LanguageIdentifier,
     pub extensions: extensions::ExtensionsMap,


### PR DESCRIPTION
I would like to use ordering by `LanguageIdentifier` to sort list of pluralrules and be able to `binary_search` through them.

I *think* it makes sense to sort, and the sorting over `TinyStr` should work since it's basically ASCII.

@Manishearth , @raphlinus - can you check my reasoning? Is there any risk on be/le side?