### PR TITLE
Implement RFC #344 

### DIFF
--- a/unic-langid-impl/benches/langid.rs
+++ b/unic-langid-impl/benches/langid.rs
@@ -50,7 +50,7 @@ fn language_identifier_construct_bench(c: &mut Criterion) {
             let entries: Vec<(Option<&str>, Option<&str>, Option<&str>, Vec<&str>)> = langids
                 .iter()
                 .map(|langid| {
-                    let lang = Some(langid.get_language()).and_then(|s| {
+                    let lang = Some(langid.language()).and_then(|s| {
                         if s == "und" {
                             None
                         } else {
@@ -59,9 +59,9 @@ fn language_identifier_construct_bench(c: &mut Criterion) {
                     });
                     (
                         lang,
-                        langid.get_script(),
-                        langid.get_region(),
-                        langid.get_variants().collect::<Vec<_>>(),
+                        langid.script(),
+                        langid.region(),
+                        langid.variants().collect::<Vec<_>>(),
                     )
                 })
                 .collect();

--- a/unic-langid-impl/src/bin/generate_layout.rs
+++ b/unic-langid-impl/src/bin/generate_layout.rs
@@ -6,7 +6,7 @@ use tinystr::TinyStr8;
 use unic_langid_impl::CharacterDirection;
 use unic_langid_impl::LanguageIdentifier;
 
-fn get_langid_to_direction_map(path: &str) -> HashMap<LanguageIdentifier, CharacterDirection> {
+fn langid_to_direction_map(path: &str) -> HashMap<LanguageIdentifier, CharacterDirection> {
     let mut result = HashMap::new();
     for entry in fs::read_dir(path).unwrap() {
         let entry = entry.unwrap();
@@ -40,7 +40,7 @@ fn check_all_variants_rtl(
     lang: &str,
 ) -> bool {
     for (langid, dir) in map.iter() {
-        if langid.get_language() == lang && dir != &CharacterDirection::RTL {
+        if langid.language() == lang && dir != &CharacterDirection::RTL {
             return false;
         }
     }
@@ -49,7 +49,7 @@ fn check_all_variants_rtl(
 
 fn main() {
     let path = "./data/cldr-misc-modern/main/";
-    let map = get_langid_to_direction_map(path);
+    let map = langid_to_direction_map(path);
 
     let mut result = vec![];
 
@@ -58,7 +58,7 @@ fn main() {
             continue;
         }
 
-        let lang = langid.get_language().to_string();
+        let lang = langid.language().to_string();
 
         assert!(
             check_all_variants_rtl(&map, &lang),

--- a/unic-langid-impl/src/bin/generate_likelysubtags.rs
+++ b/unic-langid-impl/src/bin/generate_likelysubtags.rs
@@ -56,14 +56,14 @@ fn main() {
         let key_langid: LanguageIdentifier = k.parse().expect("Failed to parse a key.");
         let v: &str = v.as_str().unwrap();
         let mut value_langid: LanguageIdentifier = v.parse().expect("Failed to parse a value.");
-        if let Some("ZZ") = value_langid.get_region() {
+        if let Some("ZZ") = value_langid.region() {
             value_langid.clear_region();
         }
         let (val_lang, val_script, val_region, _) = value_langid.into_raw_parts();
 
-        let lang = key_langid.get_language();
-        let script = key_langid.get_script();
-        let region = key_langid.get_region();
+        let lang = key_langid.language();
+        let script = key_langid.script();
+        let region = key_langid.region();
 
         match (lang, script, region) {
             (l, None, None) => lang_only.push((

--- a/unic-langid-impl/src/lib.rs
+++ b/unic-langid-impl/src/lib.rs
@@ -39,10 +39,10 @@ type RawPartsTuple = (Option<u64>, Option<u32>, Option<u32>, Option<Box<[u64]>>)
 /// let li: LanguageIdentifier = "en-US".parse()
 ///     .expect("Failed to parse.");
 ///
-/// assert_eq!(li.get_language(), "en");
-/// assert_eq!(li.get_script(), None);
-/// assert_eq!(li.get_region(), Some("US"));
-/// assert_eq!(li.get_variants().len(), 0);
+/// assert_eq!(li.language(), "en");
+/// assert_eq!(li.script(), None);
+/// assert_eq!(li.region(), Some("US"));
+/// assert_eq!(li.variants().len(), 0);
 /// ```
 ///
 /// # Parsing
@@ -67,10 +67,10 @@ type RawPartsTuple = (Option<u64>, Option<u32>, Option<u32>, Option<Box<[u64]>>)
 /// let li: LanguageIdentifier = "eN_latn_Us-Valencia".parse()
 ///     .expect("Failed to parse.");
 ///
-/// assert_eq!(li.get_language(), "en");
-/// assert_eq!(li.get_script(), Some("Latn"));
-/// assert_eq!(li.get_region(), Some("US"));
-/// assert_eq!(li.get_variants().collect::<Vec<_>>(), &["valencia"]);
+/// assert_eq!(li.language(), "en");
+/// assert_eq!(li.script(), Some("Latn"));
+/// assert_eq!(li.region(), Some("US"));
+/// assert_eq!(li.variants().collect::<Vec<_>>(), &["valencia"]);
 /// ```
 #[derive(Default, Debug, PartialEq, Eq, Clone, Hash, PartialOrd, Ord)]
 pub struct LanguageIdentifier {
@@ -304,14 +304,14 @@ impl LanguageIdentifier {
     /// let li1: LanguageIdentifier = "de-AT".parse()
     ///     .expect("Parsing failed.");
     ///
-    /// assert_eq!(li1.get_language(), "de");
+    /// assert_eq!(li1.language(), "de");
     ///
     /// let li2: LanguageIdentifier = "und-AT".parse()
     ///     .expect("Parsing failed.");
     ///
-    /// assert_eq!(li2.get_language(), "und");
+    /// assert_eq!(li2.language(), "und");
     /// ```
-    pub fn get_language(&self) -> &str {
+    pub fn language(&self) -> &str {
         self.language.as_ref().map(|s| s.as_ref()).unwrap_or("und")
     }
 
@@ -368,14 +368,14 @@ impl LanguageIdentifier {
     /// let li1: LanguageIdentifier = "de-Latn-AT".parse()
     ///     .expect("Parsing failed.");
     ///
-    /// assert_eq!(li1.get_script(), Some("Latn"));
+    /// assert_eq!(li1.script(), Some("Latn"));
     ///
     /// let li2: LanguageIdentifier = "de-AT".parse()
     ///     .expect("Parsing failed.");
     ///
-    /// assert_eq!(li2.get_script(), None);
+    /// assert_eq!(li2.script(), None);
     /// ```
-    pub fn get_script(&self) -> Option<&str> {
+    pub fn script(&self) -> Option<&str> {
         self.script.as_ref().map(|s| s.as_ref())
     }
 
@@ -427,14 +427,14 @@ impl LanguageIdentifier {
     /// let li1: LanguageIdentifier = "de-Latn-AT".parse()
     ///     .expect("Parsing failed.");
     ///
-    /// assert_eq!(li1.get_region(), Some("AT"));
+    /// assert_eq!(li1.region(), Some("AT"));
     ///
     /// let li2: LanguageIdentifier = "de".parse()
     ///     .expect("Parsing failed.");
     ///
-    /// assert_eq!(li2.get_region(), None);
+    /// assert_eq!(li2.region(), None);
     /// ```
-    pub fn get_region(&self) -> Option<&str> {
+    pub fn region(&self) -> Option<&str> {
         self.region.as_ref().map(|s| s.as_ref())
     }
 
@@ -486,14 +486,14 @@ impl LanguageIdentifier {
     /// let li1: LanguageIdentifier = "ca-ES-valencia".parse()
     ///     .expect("Parsing failed.");
     ///
-    /// assert_eq!(li1.get_variants().collect::<Vec<_>>(), &["valencia"]);
+    /// assert_eq!(li1.variants().collect::<Vec<_>>(), &["valencia"]);
     ///
     /// let li2: LanguageIdentifier = "de".parse()
     ///     .expect("Parsing failed.");
     ///
-    /// assert_eq!(li2.get_variants().len(), 0);
+    /// assert_eq!(li2.variants().len(), 0);
     /// ```
-    pub fn get_variants(&self) -> impl ExactSizeIterator<Item = &str> {
+    pub fn variants(&self) -> impl ExactSizeIterator<Item = &str> {
         let variants: &[_] = match self.variants {
             Some(ref v) => &**v,
             None => &[],
@@ -640,10 +640,10 @@ impl LanguageIdentifier {
     /// let li2: LanguageIdentifier = "fa".parse()
     ///     .expect("Parsing failed.");
     ///
-    /// assert_eq!(li1.get_character_direction(), CharacterDirection::LTR);
-    /// assert_eq!(li2.get_character_direction(), CharacterDirection::RTL);
+    /// assert_eq!(li1.character_direction(), CharacterDirection::LTR);
+    /// assert_eq!(li2.character_direction(), CharacterDirection::RTL);
     /// ```
-    pub fn get_character_direction(&self) -> CharacterDirection {
+    pub fn character_direction(&self) -> CharacterDirection {
         match self.language {
             Some(lang) if CHARACTER_DIRECTION_RTL.contains(&(lang.into())) => {
                 CharacterDirection::RTL

--- a/unic-langid-impl/src/likelysubtags/mod.rs
+++ b/unic-langid-impl/src/likelysubtags/mod.rs
@@ -4,7 +4,7 @@ pub use tables::CLDR_VERSION;
 
 use tinystr::{TinyStr4, TinyStr8};
 
-unsafe fn get_lang_from_parts(
+unsafe fn lang_from_parts(
     input: (Option<u64>, Option<u32>, Option<u32>),
     lang: Option<TinyStr8>,
     script: Option<TinyStr4>,
@@ -32,7 +32,7 @@ pub fn maximize(
                 .ok();
             if let Some(r) = result {
                 // safe because all table entries are well formed.
-                return unsafe { get_lang_from_parts(tables::LANG_REGION[r].2, None, None, None) };
+                return unsafe { lang_from_parts(tables::LANG_REGION[r].2, None, None, None) };
             }
         }
 
@@ -42,7 +42,7 @@ pub fn maximize(
                 .ok();
             if let Some(r) = result {
                 // safe because all table entries are well formed.
-                return unsafe { get_lang_from_parts(tables::LANG_SCRIPT[r].2, None, None, None) };
+                return unsafe { lang_from_parts(tables::LANG_SCRIPT[r].2, None, None, None) };
             }
         }
 
@@ -51,7 +51,7 @@ pub fn maximize(
             .ok();
         if let Some(r) = result {
             // safe because all table entries are well formed.
-            return unsafe { get_lang_from_parts(tables::LANG_ONLY[r].1, None, script, region) };
+            return unsafe { lang_from_parts(tables::LANG_ONLY[r].1, None, script, region) };
         }
     } else if let Some(s) = script {
         if let Some(r) = region {
@@ -61,7 +61,7 @@ pub fn maximize(
             if let Some(r) = result {
                 // safe because all table entries are well formed.
                 return unsafe {
-                    get_lang_from_parts(tables::SCRIPT_REGION[r].2, None, None, None)
+                    lang_from_parts(tables::SCRIPT_REGION[r].2, None, None, None)
                 };
             }
         }
@@ -71,7 +71,7 @@ pub fn maximize(
             .ok();
         if let Some(r) = result {
             // safe because all table entries are well formed.
-            return unsafe { get_lang_from_parts(tables::SCRIPT_ONLY[r].1, None, None, region) };
+            return unsafe { lang_from_parts(tables::SCRIPT_ONLY[r].1, None, None, region) };
         }
     } else if let Some(r) = region {
         let result = tables::REGION_ONLY
@@ -79,7 +79,7 @@ pub fn maximize(
             .ok();
         if let Some(r) = result {
             // safe because all table entries are well formed.
-            return unsafe { get_lang_from_parts(tables::REGION_ONLY[r].1, None, None, None) };
+            return unsafe { lang_from_parts(tables::REGION_ONLY[r].1, None, None, None) };
         }
     }
 

--- a/unic-langid-impl/tests/language_identifier_test.rs
+++ b/unic-langid-impl/tests/language_identifier_test.rs
@@ -11,11 +11,11 @@ fn assert_language_identifier(
     region: Option<&str>,
     variants: Option<&[&str]>,
 ) {
-    assert_eq!(loc.get_language(), language.unwrap_or("und"));
-    assert_eq!(loc.get_script(), script);
-    assert_eq!(loc.get_region(), region);
+    assert_eq!(loc.language(), language.unwrap_or("und"));
+    assert_eq!(loc.script(), script);
+    assert_eq!(loc.region(), region);
     assert_eq!(
-        loc.get_variants().collect::<Vec<_>>(),
+        loc.variants().collect::<Vec<_>>(),
         variants.unwrap_or(&[])
     );
 }
@@ -150,8 +150,8 @@ fn test_matches_as_range() {
 fn test_character_direction() {
     let langid: LanguageIdentifier = "en-US".parse().unwrap();
     let langid2: LanguageIdentifier = "ar-AF".parse().unwrap();
-    assert_eq!(langid.get_character_direction(), CharacterDirection::LTR);
-    assert_eq!(langid2.get_character_direction(), CharacterDirection::RTL);
+    assert_eq!(langid.character_direction(), CharacterDirection::LTR);
+    assert_eq!(langid2.character_direction(), CharacterDirection::RTL);
 }
 
 #[test]

--- a/unic-langid-macros-impl/Cargo.toml
+++ b/unic-langid-macros-impl/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["internationalization"]
 proc_macro = true
 
 [dependencies]
-unic-langid-impl = "0.7"
+unic-langid-impl = { version = "0.7", path = "../unic-langid-impl" }
 syn = "1.0"
 quote = "1.0"
 proc-macro-hack = "0.5"

--- a/unic-langid-macros/Cargo.toml
+++ b/unic-langid-macros/Cargo.toml
@@ -11,6 +11,6 @@ categories = ["internationalization"]
 
 [dependencies]
 proc-macro-hack = "0.5"
-unic-langid-macros-impl = "0.7"
-unic-langid-impl = "0.7"
+unic-langid-macros-impl = { version = "0.7", path = "../unic-langid-macros-impl" } 
+unic-langid-impl = { version = "0.7", path = "../unic-langid-impl" } 
 tinystr = "0.3.2"

--- a/unic-langid/Cargo.toml
+++ b/unic-langid/Cargo.toml
@@ -10,11 +10,11 @@ license = "MIT/Apache-2.0"
 categories = ["internationalization"]
 
 [dependencies]
-unic-langid-impl = "0.7.1"
-unic-langid-macros = { version = "0.7" , optional = true }
+unic-langid-impl = { version = "0.7.1", path = "../unic-langid-impl" }
+unic-langid-macros = { version = "0.7", path = "../unic-langid-macros", optional = true }
 
 [dev-dependencies]
-unic-langid-macros = "0.7"
+unic-langid-macros = { version = "0.7", path = "../unic-langid-macros" }
 
 [features]
 default = []

--- a/unic-langid/README.md
+++ b/unic-langid/README.md
@@ -12,9 +12,9 @@ use unic_langid::LanguageIdentifier;
 
 let loc: LanguageIdentifier = "en-US".parse().expect("Parsing failed.");
 
-assert_eq!(loc.get_language(), "en");
-assert_eq!(loc.get_script(), None);
-assert_eq!(loc.get_region(), Some("US"));
+assert_eq!(loc.language(), "en");
+assert_eq!(loc.script(), None);
+assert_eq!(loc.region(), Some("US"));
 
 loc.set_script(Some("latn"));
 

--- a/unic-langid/examples/simple-langid.rs
+++ b/unic-langid/examples/simple-langid.rs
@@ -8,13 +8,13 @@ const EN_US: LanguageIdentifier = langid!("en-US");
 fn main() {
     let langid: LanguageIdentifier = "fr-CA".parse().unwrap();
     println!("{:#?}", langid);
-    assert_eq!(langid.get_language(), "fr");
+    assert_eq!(langid.language(), "fr");
 
     #[cfg(feature = "unic-langid-macros")]
     {
         let langid = langid!("de-AT");
         println!("{:#?}", langid);
-        assert_eq!(langid.get_language(), "de");
-        assert_eq!(EN_US.get_language(), "en");
+        assert_eq!(langid.language(), "de");
+        assert_eq!(EN_US.language(), "en");
     }
 }

--- a/unic-langid/src/lib.rs
+++ b/unic-langid/src/lib.rs
@@ -12,10 +12,10 @@
 //! let mut li: LanguageIdentifier = "en-US".parse()
 //!     .expect("Failed to parse.");
 //!
-//! assert_eq!(li.get_language(), "en");
-//! assert_eq!(li.get_script(), None);
-//! assert_eq!(li.get_region(), Some("US"));
-//! assert_eq!(li.get_variants().len(), 0);
+//! assert_eq!(li.language(), "en");
+//! assert_eq!(li.script(), None);
+//! assert_eq!(li.region(), Some("US"));
+//! assert_eq!(li.variants().len(), 0);
 //!
 //! li.set_region("GB")
 //!     .expect("Region parsing failed.");

--- a/unic-langid/tests/langid.rs
+++ b/unic-langid/tests/langid.rs
@@ -20,7 +20,7 @@ fn langid_macro_test() {
 fn langids_macro_test() {
     let langids = langids!["en-US", "pl", "de-AT", "Pl-Latn-PL"];
     assert_eq!(langids.len(), 4);
-    assert_eq!(langids.get(3).unwrap().get_language(), "pl");
+    assert_eq!(langids.get(3).unwrap().language(), "pl");
 }
 
 #[test]

--- a/unic-locale-impl/src/extensions/private.rs
+++ b/unic-locale-impl/src/extensions/private.rs
@@ -17,7 +17,7 @@ use tinystr::TinyStr8;
 ///     .expect("Parsing failed.");
 ///
 /// assert_eq!(loc.extensions.private.has_tag("faa"), Ok(true));
-/// assert_eq!(loc.extensions.private.get_tags().next(), Some("faa")); // tags got sorted
+/// assert_eq!(loc.extensions.private.tags().next(), Some("faa")); // tags got sorted
 /// loc.extensions.private.clear_tags();
 /// assert_eq!(loc.to_string(), "en-US");
 /// ```
@@ -81,10 +81,10 @@ impl PrivateExtensionList {
     /// let mut loc: Locale = "en-US-x-foo-bar".parse()
     ///     .expect("Parsing failed.");
     ///
-    /// assert_eq!(loc.extensions.private.get_tags().collect::<Vec<_>>(),
+    /// assert_eq!(loc.extensions.private.tags().collect::<Vec<_>>(),
     ///            &["bar", "foo"]);
     /// ```
-    pub fn get_tags(&self) -> impl ExactSizeIterator<Item = &str> {
+    pub fn tags(&self) -> impl ExactSizeIterator<Item = &str> {
         self.0.iter().map(|s| s.as_ref())
     }
 

--- a/unic-locale-impl/src/extensions/transform.rs
+++ b/unic-locale-impl/src/extensions/transform.rs
@@ -26,9 +26,9 @@ use tinystr::{TinyStr4, TinyStr8};
 /// let en_us: LanguageIdentifier = "en-US".parse()
 ///     .expect("Parsing failed.");
 ///
-/// assert_eq!(loc.extensions.transform.get_tlang(), Some(&en_us));
+/// assert_eq!(loc.extensions.transform.tlang(), Some(&en_us));
 /// assert_eq!(
-///     loc.extensions.transform.get_tfield("h0")
+///     loc.extensions.transform.tfield("h0")
 ///                             .expect("Getting tfield failed.")
 ///                             .collect::<Vec<_>>(),
 ///     &["hybrid"]
@@ -107,9 +107,9 @@ impl TransformExtensionList {
     /// let tlang: LanguageIdentifier = "es-AR".parse()
     ///     .expect("Parsing failed on tlang.");
     ///
-    /// assert_eq!(loc.extensions.transform.get_tlang(), Some(&tlang));
+    /// assert_eq!(loc.extensions.transform.tlang(), Some(&tlang));
     /// ```
-    pub fn get_tlang(&self) -> Option<&LanguageIdentifier> {
+    pub fn tlang(&self) -> Option<&LanguageIdentifier> {
         self.tlang.as_ref()
     }
 
@@ -166,19 +166,19 @@ impl TransformExtensionList {
     /// let mut loc: Locale = "en-US-t-k0-dvorak".parse()
     ///     .expect("Parsing failed.");
     ///
-    /// assert_eq!(loc.extensions.transform.get_tfield("k0")
+    /// assert_eq!(loc.extensions.transform.tfield("k0")
     ///                .expect("Getting tfield failed.")
     ///                .collect::<Vec<_>>(),
     ///            &["dvorak"]);
     ///
     /// // Here tfield with tkey "m0" is not available
-    /// assert_eq!(loc.extensions.transform.get_tfield("m0")
+    /// assert_eq!(loc.extensions.transform.tfield("m0")
     ///                .expect("Getting tfield failed.")
     ///                .collect::<Vec<_>>()
     ///                .is_empty(),
     ///            true);
     /// ```
-    pub fn get_tfield<S: AsRef<[u8]>>(
+    pub fn tfield<S: AsRef<[u8]>>(
         &self,
         tkey: S,
     ) -> Result<impl ExactSizeIterator<Item = &str>, LocaleError> {
@@ -200,10 +200,10 @@ impl TransformExtensionList {
     /// let mut loc: Locale = "en-US-t-k0-dvorak-h0-hybrid".parse()
     ///     .expect("Parsing failed.");
     ///
-    /// assert_eq!(loc.extensions.transform.get_tfield_keys().collect::<Vec<_>>(),
+    /// assert_eq!(loc.extensions.transform.tfield_keys().collect::<Vec<_>>(),
     ///            &["h0", "k0"]);
     /// ```
-    pub fn get_tfield_keys(&self) -> impl ExactSizeIterator<Item = &str> {
+    pub fn tfield_keys(&self) -> impl ExactSizeIterator<Item = &str> {
         self.tfields.keys().map(|s| s.as_ref())
     }
 

--- a/unic-locale-impl/src/extensions/unicode.rs
+++ b/unic-locale-impl/src/extensions/unicode.rs
@@ -27,7 +27,7 @@ const ATTR_LENGTH: RangeInclusive<usize> = 3..=8;
 /// let mut loc: Locale = "de-u-hc-h12-ca-buddhist".parse()
 ///     .expect("Parsing failed.");
 ///
-/// assert_eq!(loc.extensions.unicode.get_keyword("ca")
+/// assert_eq!(loc.extensions.unicode.keyword("ca")
 ///               .expect("Getting keyword failed.")
 ///               .collect::<Vec<_>>(),
 ///            &["buddhist"]);
@@ -116,18 +116,18 @@ impl UnicodeExtensionList {
     /// let mut loc: Locale = "en-US-u-ca-buddhist".parse()
     ///     .expect("Parsing failed.");
     ///
-    /// assert_eq!(loc.extensions.unicode.get_keyword("ca")
+    /// assert_eq!(loc.extensions.unicode.keyword("ca")
     ///                .expect("Getting keyword failed.")
     ///                .collect::<Vec<_>>(),
     ///            &["buddhist"]);
     ///
     /// // Here keyword with key "aa" is not available
-    /// assert_eq!(loc.extensions.unicode.get_keyword("aa")
+    /// assert_eq!(loc.extensions.unicode.keyword("aa")
     ///               .expect("Getting keyword failed.")
     ///               .len(),
     ///            0);
     /// ```
-    pub fn get_keyword<S: AsRef<[u8]>>(
+    pub fn keyword<S: AsRef<[u8]>>(
         &self,
         key: S,
     ) -> Result<impl ExactSizeIterator<Item = &str>, LocaleError> {
@@ -149,10 +149,10 @@ impl UnicodeExtensionList {
     /// let mut loc: Locale = "en-US-u-ca-buddhist-nu-thai".parse()
     ///     .expect("Parsing failed.");
     ///
-    /// assert_eq!(loc.extensions.unicode.get_keyword_keys().collect::<Vec<_>>(),
+    /// assert_eq!(loc.extensions.unicode.keyword_keys().collect::<Vec<_>>(),
     ///            &["ca", "nu"]);
     /// ```
-    pub fn get_keyword_keys(&self) -> impl ExactSizeIterator<Item = &str> {
+    pub fn keyword_keys(&self) -> impl ExactSizeIterator<Item = &str> {
         self.keywords.keys().map(|s| s.as_ref())
     }
 
@@ -259,10 +259,10 @@ impl UnicodeExtensionList {
     /// let mut loc: Locale = "en-US-u-foo-bar".parse()
     ///     .expect("Parsing failed.");
     ///
-    /// assert_eq!(loc.extensions.unicode.get_attributes().collect::<Vec<_>>(),
+    /// assert_eq!(loc.extensions.unicode.attributes().collect::<Vec<_>>(),
     ///            &["bar", "foo"]);
     /// ```
-    pub fn get_attributes(&self) -> impl ExactSizeIterator<Item = &str> {
+    pub fn attributes(&self) -> impl ExactSizeIterator<Item = &str> {
         self.attributes.iter().map(|s| s.as_ref())
     }
 

--- a/unic-locale-impl/src/lib.rs
+++ b/unic-locale-impl/src/lib.rs
@@ -27,11 +27,11 @@ pub use unic_langid_impl::LanguageIdentifier;
 /// let loc: Locale = "en-US-u-ca-buddhist".parse()
 ///     .expect("Failed to parse.");
 ///
-/// assert_eq!(loc.get_language(), "en");
-/// assert_eq!(loc.get_script(), None);
-/// assert_eq!(loc.get_region(), Some("US"));
-/// assert_eq!(loc.get_variants().len(), 0);
-/// assert_eq!(loc.extensions.unicode.get_keyword("ca")
+/// assert_eq!(loc.language(), "en");
+/// assert_eq!(loc.script(), None);
+/// assert_eq!(loc.region(), Some("US"));
+/// assert_eq!(loc.variants().len(), 0);
+/// assert_eq!(loc.extensions.unicode.keyword("ca")
 ///     .expect("Getting keyword failed.")
 ///     .collect::<Vec<_>>(),
 ///     &["buddhist"]);
@@ -59,10 +59,10 @@ pub use unic_langid_impl::LanguageIdentifier;
 /// let loc: Locale = "eN_latn_Us-Valencia_u-hC-H12".parse()
 ///     .expect("Failed to parse.");
 ///
-/// assert_eq!(loc.get_language(), "en");
-/// assert_eq!(loc.get_script(), Some("Latn"));
-/// assert_eq!(loc.get_region(), Some("US"));
-/// assert_eq!(loc.get_variants().collect::<Vec<_>>(), &["valencia"]);
+/// assert_eq!(loc.language(), "en");
+/// assert_eq!(loc.script(), Some("Latn"));
+/// assert_eq!(loc.region(), Some("US"));
+/// assert_eq!(loc.variants().collect::<Vec<_>>(), &["valencia"]);
 /// ```
 #[derive(Debug, Default, PartialEq, Eq, Clone, Hash, PartialOrd, Ord)]
 pub struct Locale {
@@ -244,15 +244,15 @@ impl Locale {
     /// let loc1: Locale = "de-AT".parse()
     ///     .expect("Parsing failed.");
     ///
-    /// assert_eq!(loc1.get_language(), "de");
+    /// assert_eq!(loc1.language(), "de");
     ///
     /// let loc2: Locale = "und-AT".parse()
     ///     .expect("Parsing failed.");
     ///
-    /// assert_eq!(loc2.get_language(), "und");
+    /// assert_eq!(loc2.language(), "und");
     /// ```
-    pub fn get_language(&self) -> &str {
-        self.langid.get_language()
+    pub fn language(&self) -> &str {
+        self.langid.language()
     }
 
     /// Sets the language subtag of the `Locale`.
@@ -304,15 +304,15 @@ impl Locale {
     /// let loc1: Locale = "de-Latn-AT".parse()
     ///     .expect("Parsing failed.");
     ///
-    /// assert_eq!(loc1.get_script(), Some("Latn"));
+    /// assert_eq!(loc1.script(), Some("Latn"));
     ///
     /// let loc2: Locale = "de-AT".parse()
     ///     .expect("Parsing failed.");
     ///
-    /// assert_eq!(loc2.get_script(), None);
+    /// assert_eq!(loc2.script(), None);
     /// ```
-    pub fn get_script(&self) -> Option<&str> {
-        self.langid.get_script()
+    pub fn script(&self) -> Option<&str> {
+        self.langid.script()
     }
 
     /// Sets the script subtag of the `Locale`.
@@ -362,15 +362,15 @@ impl Locale {
     /// let loc1: Locale = "de-Latn-AT".parse()
     ///     .expect("Parsing failed.");
     ///
-    /// assert_eq!(loc1.get_region(), Some("AT"));
+    /// assert_eq!(loc1.region(), Some("AT"));
     ///
     /// let loc2: Locale = "de".parse()
     ///     .expect("Parsing failed.");
     ///
-    /// assert_eq!(loc2.get_region(), None);
+    /// assert_eq!(loc2.region(), None);
     /// ```
-    pub fn get_region(&self) -> Option<&str> {
-        self.langid.get_region()
+    pub fn region(&self) -> Option<&str> {
+        self.langid.region()
     }
 
     /// Sets the region subtag of the `Locale`.
@@ -420,15 +420,15 @@ impl Locale {
     /// let loc1: Locale = "ca-ES-valencia".parse()
     ///     .expect("Parsing failed.");
     ///
-    /// assert_eq!(loc1.get_variants().collect::<Vec<_>>(), &["valencia"]);
+    /// assert_eq!(loc1.variants().collect::<Vec<_>>(), &["valencia"]);
     ///
     /// let loc2: Locale = "de".parse()
     ///     .expect("Parsing failed.");
     ///
-    /// assert_eq!(loc2.get_variants().len(), 0);
+    /// assert_eq!(loc2.variants().len(), 0);
     /// ```
-    pub fn get_variants(&self) -> impl ExactSizeIterator<Item = &str> {
-        self.langid.get_variants()
+    pub fn variants(&self) -> impl ExactSizeIterator<Item = &str> {
+        self.langid.variants()
     }
 
     /// Sets variant subtags of the `Locale`.
@@ -538,11 +538,11 @@ impl Locale {
     /// let loc2: Locale = "fa".parse()
     ///     .expect("Parsing failed.");
     ///
-    /// assert_eq!(loc1.get_character_direction(), CharacterDirection::LTR);
-    /// assert_eq!(loc2.get_character_direction(), CharacterDirection::RTL);
+    /// assert_eq!(loc1.character_direction(), CharacterDirection::LTR);
+    /// assert_eq!(loc2.character_direction(), CharacterDirection::RTL);
     /// ```
-    pub fn get_character_direction(&self) -> CharacterDirection {
-        self.langid.get_character_direction()
+    pub fn character_direction(&self) -> CharacterDirection {
+        self.langid.character_direction()
     }
 }
 

--- a/unic-locale-impl/tests/locale_test.rs
+++ b/unic-locale-impl/tests/locale_test.rs
@@ -45,14 +45,14 @@ fn test_locale_identifier() {
 
     let val = extensions
         .unicode
-        .get_keyword("hc")
+        .keyword("hc")
         .unwrap()
         .collect::<Vec<_>>();
     assert_eq!(val, &["h12"]);
 
     let val = extensions
         .unicode
-        .get_keyword("aa")
+        .keyword("aa")
         .unwrap()
         .collect::<Vec<_>>();
     assert_eq!(val.is_empty(), true);
@@ -76,14 +76,14 @@ fn test_locale_identifier() {
 
     let val = extensions
         .transform
-        .get_tfield("m0")
+        .tfield("m0")
         .unwrap()
         .collect::<Vec<_>>();
     assert_eq!(val, &["foo"]);
 
     let val = extensions
         .transform
-        .get_tfield("x0")
+        .tfield("x0")
         .unwrap()
         .collect::<Vec<_>>();
     assert_eq!(val.is_empty(), true);
@@ -201,12 +201,12 @@ fn test_likelysubtags() {
 }
 
 #[test]
-fn test_get_character_direction() {
+fn test_character_direction() {
     let loc_en: Locale = "en-u-hc-h12".parse().unwrap();
-    assert_eq!(loc_en.get_character_direction(), CharacterDirection::LTR);
+    assert_eq!(loc_en.character_direction(), CharacterDirection::LTR);
 
     let loc_ar: Locale = "ar-AF-u-hc-h12".parse().unwrap();
-    assert_eq!(loc_ar.get_character_direction(), CharacterDirection::RTL);
+    assert_eq!(loc_ar.character_direction(), CharacterDirection::RTL);
 }
 
 #[test]

--- a/unic-locale-macros-impl/Cargo.toml
+++ b/unic-locale-macros-impl/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["internationalization"]
 proc_macro = true
 
 [dependencies]
-unic-locale-impl = "0.7"
+unic-locale-impl = { version = "0.7", path = "../unic-locale-impl" }
 syn = "1.0"
 quote = "1.0"
 proc-macro-hack = "0.5"

--- a/unic-locale-macros/Cargo.toml
+++ b/unic-locale-macros/Cargo.toml
@@ -12,5 +12,5 @@ categories = ["internationalization"]
 [dependencies]
 proc-macro-hack = "0.5"
 tinystr = "0.3.2"
-unic-locale-macros-impl = "0.7"
-unic-locale-impl = "0.7"
+unic-locale-macros-impl = { version = "0.7", path = "../unic-locale-macros-impl" }
+unic-locale-impl = { version = "0.7", path = "../unic-locale-impl" }

--- a/unic-locale/Cargo.toml
+++ b/unic-locale/Cargo.toml
@@ -10,12 +10,12 @@ license = "MIT/Apache-2.0"
 categories = ["internationalization"]
 
 [dependencies]
-unic-langid-impl = "0.7.1"
-unic-locale-impl = "0.7.1"
-unic-locale-macros = { version = "0.7" , optional = true }
+unic-langid-impl = { version = "0.7.1", path = "../unic-langid-impl" }
+unic-locale-impl = { version = "0.7.1", path = "../unic-locale-impl" }
+unic-locale-macros = { version = "0.7", path = "../unic-locale-macros", optional = true }
 
 [dev-dependencies]
-unic-locale-macros = "0.7"
+unic-locale-macros = { version = "0.7", path = "../unic-locale-macros" }
 
 [features]
 default = []

--- a/unic-locale/README.md
+++ b/unic-locale/README.md
@@ -13,14 +13,14 @@ use unic_locale::{Locale, ExtensionType};
 let loc: Locale = "en-US-u-hc-h12".parse()
     .expect("Parsing.failed");
 
-assert_eq!(loc.get_language(), "en");
-assert_eq!(loc.get_script(), None);
-assert_eq!(loc.get_region(), Some("US"));
+assert_eq!(loc.language(), "en");
+assert_eq!(loc.script(), None);
+assert_eq!(loc.region(), Some("US"));
 
 loc.extensions.unicode.set_keyword("ca", "buddhist")
     .expect("Setting extension failed.");
 
-let val = loc.extensions.unicode.get_keyword("ca")
+let val = loc.extensions.unicode.keyword("ca")
     .expect("Getting extension value failed.")
     .collect::<Vec<_>>();
 

--- a/unic-locale/examples/simple-locale.rs
+++ b/unic-locale/examples/simple-locale.rs
@@ -11,13 +11,13 @@ fn main() {
         .expect("Setting extension failed.");
 
     println!("{:#?}", locale);
-    assert_eq!(locale.get_language(), "fr");
+    assert_eq!(locale.language(), "fr");
     assert_eq!(&locale.to_string(), "fr-CA-u-ca-buddhist");
 
     #[cfg(feature = "macros")]
     {
         let langid = locale!("de-AT");
         println!("{:#?}", langid);
-        assert_eq!(langid.get_language(), "de");
+        assert_eq!(langid.language(), "de");
     }
 }

--- a/unic-locale/src/lib.rs
+++ b/unic-locale/src/lib.rs
@@ -20,14 +20,14 @@
 //! let mut loc: Locale = "en-Latn-US-u-hc-h12-t-h0-hybrid".parse()
 //!     .expect("Failed to parse.");
 //!
-//! assert_eq!(loc.get_language(), "en");
-//! assert_eq!(loc.get_script(), Some("Latn"));
-//! assert_eq!(loc.get_region(), Some("US"));
-//! assert_eq!(loc.get_variants().len(), 0);
-//! assert_eq!(loc.extensions.unicode.get_keyword("hc")
+//! assert_eq!(loc.language(), "en");
+//! assert_eq!(loc.script(), Some("Latn"));
+//! assert_eq!(loc.region(), Some("US"));
+//! assert_eq!(loc.variants().len(), 0);
+//! assert_eq!(loc.extensions.unicode.keyword("hc")
 //!     .expect("Getting keyword failed.")
 //!     .collect::<Vec<_>>(), &["h12"]);
-//! assert_eq!(loc.extensions.transform.get_tfield("h0")
+//! assert_eq!(loc.extensions.transform.tfield("h0")
 //!     .expect("Getting tfield failed.")
 //!     .collect::<Vec<_>>(), &["hybrid"]);
 //!

--- a/unic-locale/tests/locale.rs
+++ b/unic-locale/tests/locale.rs
@@ -20,14 +20,14 @@ fn locale_macro_test() {
 fn locales_macro_test() {
     let locales = locales!["en-US-u-ca-buddhist", "pl", "de-AT-u-hc-h12", "Pl-Latn-PL"];
     assert_eq!(locales.len(), 4);
-    assert_eq!(locales.get(3).unwrap().get_language(), "pl");
+    assert_eq!(locales.get(3).unwrap().language(), "pl");
     assert_eq!(
         locales
             .get(0)
             .unwrap()
             .extensions
             .unicode
-            .get_keyword("ca")
+            .keyword("ca")
             .unwrap()
             .collect::<Vec<_>>(),
         &["buddhist"]


### PR DESCRIPTION
Hey! Super impressed with the state of this crate, and hope to use it for some projects very soon. :smile:

One thing that immediately jumped out at me however was the use of `get_` prefixes for several functions, which is unidiomatic Rust, as specified in [RFC #344](https://doc.rust-lang.org/1.0.0/style/style/naming/README.html#getter/setter-methods-[rfc-344]).

This patch fixes that, all tests are passing, and also ensures that the `Cargo.toml` uses the local crates for testing, while not stopping `cargo publish` from working.