### PR TITLE
Allow macros `langids` and `locales` to be used without having their singular counterpart in scope

### DIFF
--- a/unic-langid/src/lib.rs
+++ b/unic-langid/src/lib.rs
@@ -113,11 +113,9 @@ pub use unic_langid_macros::{lang, langid, region, script, variant};
 macro_rules! langids {
     ( $($langid:expr),* ) => {
         {
-            let mut v = vec![];
-            $(
-                v.push(langid!($langid));
-            )*
-            v
+            vec![$(
+                $crate::langid!($langid),
+            )*]
         }
     };
 }

--- a/unic-locale/src/lib.rs
+++ b/unic-locale/src/lib.rs
@@ -110,11 +110,9 @@ pub use unic_locale_macros::locale;
 macro_rules! locales {
     ( $($loc:expr),* ) => {
         {
-            let mut v = vec![];
-            $(
-                v.push(locale!($loc));
-            )*
-            v
+            vec![$(
+                $crate::locale!($loc),
+            )*]
         }
     };
 }


### PR DESCRIPTION
In order to use the `langids!` macro one currently has to add `langid!` to the scope. The same goes for the `locales!` macro.
This not only makes it annoying to use  the syntax `unic_langid::langids!` but could also lead to bugs if the current scope defines a different macro with the name `langid` which would be used instead.

This PR fixes this by using the special variable [`$crate`](https://doc.rust-lang.org/1.7.0/book/macros.html#the-variable-crate).
It also simplifies the implementation of the macros by passing the values to the `vec!` which should yield better performance.

As a side note, how do you feel about adding a slice variant for these macros? It would make it possible to declare a static or even constant slice of language identifiers like this:
```rust
const SUPPORTED_LANGUAGES: &[LanguageIdentifier] = unic_langid::langid_slice!["de-DE", "en-GB"];
```