### PR TITLE
Add langid_slice! macro

### DIFF
--- a/unic-langid/src/lib.rs
+++ b/unic-langid/src/lib.rs
@@ -30,13 +30,13 @@
 //!
 //! # Optional features
 //!
-//! ## `langid!` and `langids!` macros
+//! ## `langid!`, `langids!`, and `langid_slice!` macros
 //!
 //! If `feature = "macros"` is selected, the crate provides a procedural macro
 //! which allows to construct build-time well-formed language identifiers with zero-cost at runtime.
 //!
 //! ``` ignore
-//! use unic_langid::{langid, langids, lang, region, script, variant};
+//! use unic_langid::{langid, langid_slice, langids, lang, region, script, variant, LanguageIdentifier};
 //! use unic_langid::subtags::{Language, Script, Region, Variant};
 //! use std::str::FromStr;
 //!
@@ -51,6 +51,8 @@
 //! assert_eq!(lang_ids[0], "es-AR");
 //! assert_eq!(lang_ids[1], "en-US");
 //! assert_eq!(lang_ids[2], "de");
+//!
+//! const LANGUAGES: &[LanguageIdentifier] = langid_slice!["en-GB", "fr"];
 //!
 //! assert_eq!(lang!("pl"), "pl");
 //! assert_eq!(lang!("pl"), Language::from_str("pl").unwrap());
@@ -112,10 +114,23 @@ pub use unic_langid_macros::{lang, langid, region, script, variant};
 #[macro_export]
 macro_rules! langids {
     ( $($langid:expr),* ) => {
-        {
-            vec![$(
-                $crate::langid!($langid),
-            )*]
-        }
+        vec![$(
+            $crate::langid!($langid),
+        )*]
+    };
+    ( $($langid:expr,)* ) => {
+        $crate::langids![$($langid),*]
+    };
+}
+#[cfg(feature = "unic-langid-macros")]
+#[macro_export]
+macro_rules! langid_slice {
+    ( $($langid:expr),* ) => {
+        &[$(
+            $crate::langid!($langid),
+        )*]
+    };
+    ( $($langid:expr,)* ) => {
+        $crate::langid_slice![$($langid),*]
     };
 }

--- a/unic-langid/tests/langid.rs
+++ b/unic-langid/tests/langid.rs
@@ -1,6 +1,6 @@
 use unic_langid::LanguageIdentifier;
 #[cfg(feature = "unic-langid-macros")]
-use unic_langid::{langid, langids};
+use unic_langid::{langid, langid_slice, langids};
 
 #[test]
 fn basic_test() {
@@ -13,6 +13,9 @@ fn basic_test() {
 fn langid_macro_test() {
     let loc = langid!("en-US");
     assert_eq!(&loc.to_string(), "en-US");
+
+    // ensure it can be used in a const context
+    const _: LanguageIdentifier = langid!("en-US");
 }
 
 #[test]
@@ -21,6 +24,23 @@ fn langids_macro_test() {
     let langids = langids!["en-US", "pl", "de-AT", "Pl-Latn-PL"];
     assert_eq!(langids.len(), 4);
     assert_eq!(langids.get(3).unwrap().language.as_str(), "pl");
+
+    // check trailing comma
+    langids!["en-US", "pl",];
+}
+
+#[test]
+#[cfg(feature = "unic-langid-macros")]
+fn langid_slice_macro_test() {
+    let langids = langids!["en-US", "pl", "de-AT", "Pl-Latn-PL"];
+
+    // ensure it can be used in a const context
+    const CONST_LANGIDS: &[LanguageIdentifier] =
+        langid_slice!["en-US", "pl", "de-AT", "Pl-Latn-PL"];
+    assert_eq!(CONST_LANGIDS, langids.as_slice());
+
+    // check trailing comma
+    langid_slice!["en-US", "pl",];
 }
 
 #[test]

--- a/unic-locale/src/lib.rs
+++ b/unic-locale/src/lib.rs
@@ -65,8 +65,7 @@
 //! The macros produce instances of `Locale` the same way as parsing from `&str` does,
 //! but since the parsing is performed at build time, it doesn't need a `Result`.
 //!
-//! At the moment `locale!` can also be used for const variables, but only if no variants or extensions
-//! are used.
+//! Unlike `langid!` `locale!` can't be used for const variables.
 //!
 //! The macros are optional to reduce the dependency chain and compilation time of `unic-locale`.
 //!
@@ -108,11 +107,12 @@ pub use unic_locale_macros::locale;
 #[cfg(feature = "unic-locale-macros")]
 #[macro_export]
 macro_rules! locales {
-    ( $($loc:expr),* ) => {
-        {
-            vec![$(
-                $crate::locale!($loc),
-            )*]
-        }
+    ( $($locale:expr),* ) => {
+        vec![$(
+            $crate::locale!($locale),
+        )*]
+    };
+    ( $($locale:expr,)* ) => {
+        $crate::locales![$($locale),*]
     };
 }

--- a/unic-locale/tests/locale.rs
+++ b/unic-locale/tests/locale.rs
@@ -32,4 +32,7 @@ fn locales_macro_test() {
             .collect::<Vec<_>>(),
         &["buddhist"]
     );
+
+    // check trailing comma
+    locales!["en-US-u-ca-buddhist", "pl",];
 }


### PR DESCRIPTION
As mentioned in #60 here's a PR that adds a new macro `langid_slice!` which can be used in a const context.
The PR also makes it possible to call the various macros with a trailing comma to reflect the standard library.

It turns out that the `locale!` macro can't be used in a const context because it relies on the `ExtensionsMap::parse` function.
Since the `ExtensionsMap` contains various non-const members like `BTreeMap` it isn't possible to create a const fn constructor for it either.
I see no point for a slice macro if you can't use it for const or static so I didn't add it to the locale crate.
The PR updates the documentation of the `unic-locale` crate to reflect this.
