### PR TITLE
fix(unic-langid): include test files in crate

### DIFF
--- a/unic-langid-impl/Cargo.toml
+++ b/unic-langid-impl/Cargo.toml
@@ -11,6 +11,7 @@ categories = ["internationalization"]
 include = [
 	"src/**/*",
 	"benches/*.rs",
+	"tests/*.rs",
 	"Cargo.toml",
 	"README.md"
 ]


### PR DESCRIPTION
Include test files with the crate distribution. This makes the test suite pass
when running the tests from within the crate alone.

Fixes: #64