### PR TITLE
Update tinystr dep

### DIFF
--- a/unic-langid-impl/Cargo.toml
+++ b/unic-langid-impl/Cargo.toml
@@ -17,7 +17,7 @@ include = [
 ]
 
 [dependencies]
-tinystr = "0.3.2"
+tinystr = "0.7.0"
 serde = { version = "1.0", optional = true }
 serde_json = { version = "1.0", optional = true }
 

--- a/unic-langid-impl/src/bin/generate_likelysubtags.rs
+++ b/unic-langid-impl/src/bin/generate_likelysubtags.rs
@@ -1,6 +1,5 @@
 use serde_json::Value;
 use std::fs;
-use std::str::FromStr;
 use tinystr::TinyStr8;
 use unic_langid_impl::{subtags, LanguageIdentifier};
 
@@ -77,7 +76,7 @@ fn main() {
 
         match (lang, script, region) {
             (None, None, None) => lang_only.push((
-                TinyStr8::from_str("und").unwrap().into(),
+                u64::from_le_bytes(*TinyStr8::from_str("und").unwrap().all_bytes()),
                 (val_lang, val_script, val_region),
             )),
             (Some(l), None, None) => lang_only.push((

--- a/unic-langid-impl/src/subtags/language.rs
+++ b/unic-langid-impl/src/subtags/language.rs
@@ -34,7 +34,7 @@ impl Language {
     /// This function accepts any u64 that is exected to be a valid
     /// `TinyStr8` and a valid `Language` subtag.
     pub const unsafe fn from_raw_unchecked(v: u64) -> Self {
-        Self(Some(TinyStr8::new_unchecked(v)))
+        Self(Some(TinyStr8::from_bytes_unchecked(v.to_le_bytes())))
     }
 
     pub fn matches<O: Borrow<Self>>(
@@ -59,13 +59,13 @@ impl Language {
 
 impl From<Language> for Option<u64> {
     fn from(input: Language) -> Self {
-        input.0.map(|i| i.into())
+        input.0.map(|i| u64::from_le_bytes(*i.all_bytes()))
     }
 }
 
 impl From<&Language> for Option<u64> {
     fn from(input: &Language) -> Self {
-        input.0.map(|i| i.into())
+        input.0.map(|i| u64::from_le_bytes(*i.all_bytes()))
     }
 }
 

--- a/unic-langid-impl/src/subtags/region.rs
+++ b/unic-langid-impl/src/subtags/region.rs
@@ -37,13 +37,13 @@ impl Region {
     /// This function accepts any u64 that is exected to be a valid
     /// `TinyStr4` and a valid `Region` subtag.
     pub const unsafe fn from_raw_unchecked(v: u32) -> Self {
-        Self(TinyStr4::new_unchecked(v))
+        Self(TinyStr4::from_bytes_unchecked(v.to_le_bytes()))
     }
 }
 
 impl From<Region> for u32 {
     fn from(input: Region) -> Self {
-        input.0.into()
+        u32::from_le_bytes(*input.0.all_bytes())
     }
 }
 

--- a/unic-langid-impl/src/subtags/script.rs
+++ b/unic-langid-impl/src/subtags/script.rs
@@ -25,13 +25,13 @@ impl Script {
     /// This function accepts any u64 that is exected to be a valid
     /// `TinyStr4` and a valid `Script` subtag.
     pub const unsafe fn from_raw_unchecked(v: u32) -> Self {
-        Self(TinyStr4::new_unchecked(v))
+        Self(TinyStr4::from_bytes_unchecked(v.to_le_bytes()))
     }
 }
 
 impl From<Script> for u32 {
     fn from(input: Script) -> Self {
-        input.0.into()
+        u32::from_le_bytes(*input.0.all_bytes())
     }
 }
 

--- a/unic-langid-impl/src/subtags/variant.rs
+++ b/unic-langid-impl/src/subtags/variant.rs
@@ -35,19 +35,19 @@ impl Variant {
     /// This function accepts any u64 that is exected to be a valid
     /// `TinyStr8` and a valid `Variant` subtag.
     pub const unsafe fn from_raw_unchecked(v: u64) -> Self {
-        Self(TinyStr8::new_unchecked(v))
+        Self(TinyStr8::from_bytes_unchecked(v.to_le_bytes()))
     }
 }
 
 impl From<Variant> for u64 {
     fn from(input: Variant) -> Self {
-        input.0.into()
+        u64::from_le_bytes(*input.0.all_bytes())
     }
 }
 
 impl From<&Variant> for u64 {
     fn from(input: &Variant) -> Self {
-        input.0.into()
+        u64::from_le_bytes(*input.0.all_bytes())
     }
 }
 

--- a/unic-langid-macros/Cargo.toml
+++ b/unic-langid-macros/Cargo.toml
@@ -19,4 +19,4 @@ include = [
 proc-macro-hack = "0.5"
 unic-langid-macros-impl = { version = "0.9", path = "../unic-langid-macros-impl" }
 unic-langid-impl = { version = "0.9", path = "../unic-langid-impl" }
-tinystr = "0.3.2"
+tinystr = "0.7.0"

--- a/unic-locale-impl/Cargo.toml
+++ b/unic-locale-impl/Cargo.toml
@@ -17,7 +17,7 @@ include = [
 
 [dependencies]
 unic-langid-impl = { version = "0.9", path = "../unic-langid-impl" }
-tinystr = "0.3.2"
+tinystr = "0.7.0"
 
 [dev-dependencies]
 criterion = "0.3"

--- a/unic-locale-impl/src/extensions/transform.rs
+++ b/unic-locale-impl/src/extensions/transform.rs
@@ -53,7 +53,7 @@ fn parse_tkey(key: &[u8]) -> Result<TinyStr4, ParserError> {
     Ok(tkey.to_ascii_lowercase())
 }
 
-const TRUE_TVALUE: TinyStr8 = unsafe { TinyStr8::new_unchecked(1_702_195_828u64) }; // "true"
+const TRUE_TVALUE: TinyStr8 = tinystr::tinystr!(8, "true"); // "true"
 
 fn parse_tvalue(t: &[u8]) -> Result<Option<TinyStr8>, ParserError> {
     let s = TinyStr8::from_bytes(t).map_err(|_| ParserError::InvalidSubtag)?;

--- a/unic-locale-impl/src/extensions/unicode.rs
+++ b/unic-locale-impl/src/extensions/unicode.rs
@@ -52,7 +52,7 @@ fn parse_key(key: &[u8]) -> Result<TinyStr4, ParserError> {
     Ok(key.to_ascii_lowercase())
 }
 
-const TRUE_TYPE: TinyStr8 = unsafe { TinyStr8::new_unchecked(1_702_195_828u64) }; // "true"
+const TRUE_TYPE: TinyStr8 = tinystr::tinystr!(8, "true"); // "true"
 
 fn parse_type(t: &[u8]) -> Result<Option<TinyStr8>, ParserError> {
     let s = TinyStr8::from_bytes(t).map_err(|_| ParserError::InvalidSubtag)?;

--- a/unic-locale-macros/Cargo.toml
+++ b/unic-locale-macros/Cargo.toml
@@ -17,6 +17,6 @@ include = [
 
 [dependencies]
 proc-macro-hack = "0.5"
-tinystr = "0.3.2"
+tinystr = "0.7.0"
 unic-locale-macros-impl = { version = "0.9", path = "../unic-locale-macros-impl" }
 unic-locale-impl = { version = "0.9", path = "../unic-locale-impl" }


### PR DESCRIPTION
I'd like to not have any deps in the wild depending on older tinystr, and this is an indirect dep of fluent.

Ideally the le-integer based APIs would be removed (or even better, fluent moves to icu_locid), but for now I tried to make these changes as small as possible.

Can I get a point release with these?