### PR TITLE
Fix character_direction for locales using both LTR & RTL scripts

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,4 +19,4 @@ jobs:
     - name: Build
       run: cargo build --verbose
     - name: Run tests
-      run: cargo test --verbose
+      run: cargo test --all-features --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,4 +19,5 @@ jobs:
     - name: Build
       run: cargo build --verbose
     - name: Run tests
+      run: cargo test --verbose
       run: cargo test --all-features --verbose

--- a/unic-langid-impl/src/lib.rs
+++ b/unic-langid-impl/src/lib.rs
@@ -433,6 +433,12 @@ impl LanguageIdentifier {
                 CharacterDirection::TTB
             }
             (Some(lang), _) if layout_table::LANGS_CHARACTER_DIRECTION_RTL.contains(&lang) => {
+                #[cfg(feature = "likelysubtags")]
+                if let Some(max) = likelysubtags::maximize(self.language, None, self.region) {
+                    if layout_table::SCRIPTS_CHARACTER_DIRECTION_LTR.contains(max.script) {
+                        return CharacterDirection::LTR
+                    }
+                }
                 CharacterDirection::RTL
             }
             _ => CharacterDirection::LTR,

--- a/unic-langid-impl/src/lib.rs
+++ b/unic-langid-impl/src/lib.rs
@@ -434,9 +434,11 @@ impl LanguageIdentifier {
             }
             (Some(lang), _) if layout_table::LANGS_CHARACTER_DIRECTION_RTL.contains(&lang) => {
                 #[cfg(feature = "likelysubtags")]
-                if let Some(max) = likelysubtags::maximize(self.language, None, self.region) {
-                    if layout_table::SCRIPTS_CHARACTER_DIRECTION_LTR.contains(max.script) {
-                        return CharacterDirection::LTR
+                if let Some((_, Some(script), _)) =
+                    likelysubtags::maximize(self.language, None, self.region)
+                {
+                    if layout_table::SCRIPTS_CHARACTER_DIRECTION_LTR.contains(&script.into()) {
+                        return CharacterDirection::LTR;
                     }
                 }
                 CharacterDirection::RTL

--- a/unic-locale-impl/tests/locale_test.rs
+++ b/unic-locale-impl/tests/locale_test.rs
@@ -205,6 +205,7 @@ fn test_likelysubtags() {
     assert_eq!(loc_zh_hant.to_string(), "zh-TW-u-hc-h12");
 }
 
+#[cfg(not(feature = "likelysubtags"))]
 #[test]
 fn test_character_direction() {
     let loc_en: Locale = "en-u-hc-h12".parse().unwrap();
@@ -217,7 +218,10 @@ fn test_character_direction() {
     assert_eq!(loc_mn.id.character_direction(), CharacterDirection::TTB);
 
     let loc_pa_guru: Locale = "pa-Guru".parse().unwrap();
-    assert_eq!(loc_pa_guru.id.character_direction(), CharacterDirection::LTR);
+    assert_eq!(
+        loc_pa_guru.id.character_direction(),
+        CharacterDirection::LTR
+    );
 
     let loc_pa: Locale = "pa".parse().unwrap();
     assert_eq!(loc_pa.id.character_direction(), CharacterDirection::RTL);

--- a/unic-locale-impl/tests/locale_test.rs
+++ b/unic-locale-impl/tests/locale_test.rs
@@ -215,6 +215,25 @@ fn test_character_direction() {
 
     let loc_mn: Locale = "mn-Mong".parse().unwrap();
     assert_eq!(loc_mn.id.character_direction(), CharacterDirection::TTB);
+
+    let loc_pa_guru: Locale = "pa-Guru".parse().unwrap();
+    assert_eq!(loc_pa_guru.id.character_direction(), CharacterDirection::LTR);
+
+    let loc_pa: Locale = "pa".parse().unwrap();
+    assert_eq!(loc_pa.id.character_direction(), CharacterDirection::RTL);
+}
+
+#[cfg(feature = "likelysubtags")]
+#[test]
+fn test_character_direction_with_likelysubtags() {
+    let loc_pa: Locale = "pa".parse().unwrap();
+    assert_eq!(loc_pa.id.character_direction(), CharacterDirection::LTR);
+
+    let loc_pa_pk: Locale = "pa-PK".parse().unwrap();
+    assert_eq!(loc_pa_pk.id.character_direction(), CharacterDirection::RTL);
+
+    let loc_ar_us: Locale = "ar-US".parse().unwrap();
+    assert_eq!(loc_ar_us.id.character_direction(), CharacterDirection::RTL);
 }
 
 #[test]


### PR DESCRIPTION
Fixes #76

When the locale does not include a script, but for which some variants of the language do use an RTL script, we need to `likelysubtags::maximize` the locale to determine a script so that `character_direction()` can pick the right one. This way e.g. `pa` turns into `pa-Guru-IN`, which is LTR, but `pa-PK` turns into `pa-Arab-PK`, which is RTL.

Without this, the directionalities of `az`, `bm`, `ff`, `ha`, `ms`, `pa`, and `uz` are mis-reported as RTL.