### PR TITLE
Implement dummy sorting for `LanguageIdentifier`'s variants

### DIFF
--- a/unic-langid-impl/src/lib.rs
+++ b/unic-langid-impl/src/lib.rs
@@ -130,9 +130,7 @@ impl LanguageIdentifier {
         variants: &[subtags::Variant],
     ) -> Self {
         let variants = if !variants.is_empty() {
-            let mut v = variants.to_vec();
-            v.sort_unstable();
-            v.dedup();
+            let v = subtags::Variant::sort_and_deduplicate(variants);
             Some(v.into_boxed_slice())
         } else {
             None
@@ -298,13 +296,10 @@ impl LanguageIdentifier {
     /// assert_eq!(li.to_string(), "ca-ES-valencia");
     /// ```
     pub fn set_variants(&mut self, variants: &[subtags::Variant]) {
-        let mut v = variants.to_vec();
-
-        if v.is_empty() {
+        if variants.is_empty() {
             self.variants = None;
         } else {
-            v.sort_unstable();
-            v.dedup();
+            let v = subtags::Variant::sort_and_deduplicate(variants);
             self.variants = Some(v.into_boxed_slice());
         }
     }

--- a/unic-langid-impl/src/parser/mod.rs
+++ b/unic-langid-impl/src/parser/mod.rs
@@ -49,7 +49,7 @@ pub fn parse_language_identifier_from_iter<'a>(
         } else {
             // Variants
             if let Ok(v) = subtags::Variant::from_bytes(subtag) {
-                variants.push(v);
+                subtags::Variant::push_sorted_and_deduplicated(v, &mut variants);
             } else {
                 break;
             }
@@ -64,8 +64,6 @@ pub fn parse_language_identifier_from_iter<'a>(
     let variants = if variants.is_empty() {
         None
     } else {
-        variants.sort_unstable();
-        variants.dedup();
         Some(variants.into_boxed_slice())
     };
 


### PR DESCRIPTION
Resolves #53

To reproduce it, you can use the repository https://github.com/mondeja/unic-langid-impl-dummy-sorting